### PR TITLE
Add public types and entry-point stubs (#3)

### DIFF
--- a/.changeset/public-types-and-stubs.md
+++ b/.changeset/public-types-and-stubs.md
@@ -1,0 +1,14 @@
+---
+"@missingstudio/sanddune": patch
+"@missingstudio/sanddune-core": patch
+---
+
+Declare the public type surface and entry-point stubs for `run`, `createSandbox`, `createWorktree`, and `interactive`. Sandbox provider factories under `./sandboxes/{docker,podman,vercel,no-sandbox}` are exposed as stubs that throw `NotImplementedError` at runtime.
+
+Public surface introduced (defined in `@missingstudio/sanddune-core`, re-exported from `@missingstudio/sanddune`): `RunOptions`, `RunResult`, `IterationResult`, `IterationUsage`, `CompletionSignal`, `CopyToWorktree`, `CreateSandboxOptions`, `SandboxRunOptions`, `Sandbox`, `CloseResult`, `CreateWorktreeOptions`, `WorktreeRunOptions`, `WorktreeInteractiveOptions`, `WorktreeCreateSandboxOptions`, `Worktree`, `BranchStrategy` (`head` / `merge-to-head` / `branch`), `SandboxProvider`, `BindMountSandboxProvider`, `IsolatedSandboxProvider`, `NoSandboxProvider`, `BindMountSandboxHandle`, `IsolatedSandboxHandle`, `ExecResult`, `AgentProvider`, `AgentStreamEvent`, `SandboxHooks`, `HostHook`, `SandboxHook`, `Timeouts`, `LoggingOption`, `InteractiveOptions`, `NotImplementedError`, and an Effect `Context.Tag` for `AgentInvoker`.
+
+Type-level architectural rejections enforced at compile time: `head` strategy with an isolated provider, `noSandbox()` passed to `run()` or `createSandbox()`, `head` passed to `createWorktree()`, and `prompt`/`promptFile`/`promptArgs` mutual exclusion.
+
+Negative type tests are written as `@ts-expect-error` directives rather than `expect-type` / `tsd`. The directives serve the same purpose (an unused directive is itself a type error) without pulling in another devDep, and read more naturally for purely-negative cases.
+
+Both packages now emit `.d.ts` declarations via `tsc -p tsconfig.build.json` ahead of the JS bundle, so npm consumers receive types. `@missingstudio/sanddune-core` is now publishable (was internal); it remains the source of truth for public types and `@missingstudio/sanddune` re-exports from it.

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+    "permissions": {
+        "allow": [
+            "Bash(gh issue create *)",
+            "Bash(npx vitest run *)",
+            "Bash(gh repo view *)",
+            "Bash(gh issue view *)",
+            "Bash(git add:*)",
+            "Bash(git status:*)",
+            "Bash(git commit:*)",
+            "Bash(npx tsgo:*)",
+            "Bash(bun test:*)",
+            "Bash(bun check:*)",
+            "Bash(bun run typecheck *)",
+            "Bash(git merge sandcastle/*)"
+        ]
+    }
+}

--- a/.claude/skills/pre-release/SKILL.md
+++ b/.claude/skills/pre-release/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: pre-release
+description: "Run a series of pre-release checks on the repo."
+disable-model-invocation: true
+---
+
+Check all of the files in the `.changeset` directory.
+
+For the changesets as a whole, check the following:
+
+- Each changeset should be about a user-facing feature. Internal refactors or things that don't affect users should not be added as changesets.
+- Related changes should be grouped under a single changeset.
+- Changesets are user-facing, not maintainer-facing. They should not specify implementation details, or how a feature was made. They should only specify the user-facing change, and why it was made. Changesets !== commit messages.
+
+Once done, commit your changes.

--- a/.claude/skills/requesting-code-review/SKILL.md
+++ b/.claude/skills/requesting-code-review/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: requesting-code-review
+description: Use when completing tasks, implementing major features, or before merging to verify work meets requirements
+---
+
+# Requesting Code Review
+
+Dispatch superpowers:code-reviewer subagent to catch issues before they cascade. The reviewer gets precisely crafted context for evaluation — never your session's history. This keeps the reviewer focused on the work product, not your thought process, and preserves your own context for continued work.
+
+**Core principle:** Review early, review often.
+
+## When to Request Review
+
+**Mandatory:**
+- After each task in subagent-driven development
+- After completing major feature
+- Before merge to main
+
+**Optional but valuable:**
+- When stuck (fresh perspective)
+- Before refactoring (baseline check)
+- After fixing complex bug
+
+## How to Request
+
+**1. Get git SHAs:**
+```bash
+BASE_SHA=$(git rev-parse HEAD~1)  # or origin/main
+HEAD_SHA=$(git rev-parse HEAD)
+```
+
+**2. Dispatch code-reviewer subagent:**
+
+Use Task tool with superpowers:code-reviewer type, fill template at `code-reviewer.md`
+
+**Placeholders:**
+- `{WHAT_WAS_IMPLEMENTED}` - What you just built
+- `{PLAN_OR_REQUIREMENTS}` - What it should do
+- `{BASE_SHA}` - Starting commit
+- `{HEAD_SHA}` - Ending commit
+- `{DESCRIPTION}` - Brief summary
+
+**3. Act on feedback:**
+- Fix Critical issues immediately
+- Fix Important issues before proceeding
+- Note Minor issues for later
+- Push back if reviewer is wrong (with reasoning)
+
+## Example
+
+```
+[Just completed Task 2: Add verification function]
+
+You: Let me request code review before proceeding.
+
+BASE_SHA=$(git log --oneline | grep "Task 1" | head -1 | awk '{print $1}')
+HEAD_SHA=$(git rev-parse HEAD)
+
+[Dispatch superpowers:code-reviewer subagent]
+  WHAT_WAS_IMPLEMENTED: Verification and repair functions for conversation index
+  PLAN_OR_REQUIREMENTS: Task 2 from docs/superpowers/plans/deployment-plan.md
+  BASE_SHA: a7981ec
+  HEAD_SHA: 3df7661
+  DESCRIPTION: Added verifyIndex() and repairIndex() with 4 issue types
+
+[Subagent returns]:
+  Strengths: Clean architecture, real tests
+  Issues:
+    Important: Missing progress indicators
+    Minor: Magic number (100) for reporting interval
+  Assessment: Ready to proceed
+
+You: [Fix progress indicators]
+[Continue to Task 3]
+```
+
+## Integration with Workflows
+
+**Subagent-Driven Development:**
+- Review after EACH task
+- Catch issues before they compound
+- Fix before moving to next task
+
+**Executing Plans:**
+- Review after each batch (3 tasks)
+- Get feedback, apply, continue
+
+**Ad-Hoc Development:**
+- Review before merge
+- Review when stuck
+
+## Red Flags
+
+**Never:**
+- Skip review because "it's simple"
+- Ignore Critical issues
+- Proceed with unfixed Important issues
+- Argue with valid technical feedback
+
+**If reviewer wrong:**
+- Push back with technical reasoning
+- Show code/tests that prove it works
+- Request clarification
+
+See template at: requesting-code-review/code-reviewer.md

--- a/.claude/skills/requesting-code-review/code-reviewer.md
+++ b/.claude/skills/requesting-code-review/code-reviewer.md
@@ -1,0 +1,146 @@
+# Code Review Agent
+
+You are reviewing code changes for production readiness.
+
+**Your task:**
+1. Review {WHAT_WAS_IMPLEMENTED}
+2. Compare against {PLAN_OR_REQUIREMENTS}
+3. Check code quality, architecture, testing
+4. Categorize issues by severity
+5. Assess production readiness
+
+## What Was Implemented
+
+{DESCRIPTION}
+
+## Requirements/Plan
+
+{PLAN_REFERENCE}
+
+## Git Range to Review
+
+**Base:** {BASE_SHA}
+**Head:** {HEAD_SHA}
+
+```bash
+git diff --stat {BASE_SHA}..{HEAD_SHA}
+git diff {BASE_SHA}..{HEAD_SHA}
+```
+
+## Review Checklist
+
+**Code Quality:**
+- Clean separation of concerns?
+- Proper error handling?
+- Type safety (if applicable)?
+- DRY principle followed?
+- Edge cases handled?
+
+**Architecture:**
+- Sound design decisions?
+- Scalability considerations?
+- Performance implications?
+- Security concerns?
+
+**Testing:**
+- Tests actually test logic (not mocks)?
+- Edge cases covered?
+- Integration tests where needed?
+- All tests passing?
+
+**Requirements:**
+- All plan requirements met?
+- Implementation matches spec?
+- No scope creep?
+- Breaking changes documented?
+
+**Production Readiness:**
+- Migration strategy (if schema changes)?
+- Backward compatibility considered?
+- Documentation complete?
+- No obvious bugs?
+
+## Output Format
+
+### Strengths
+[What's well done? Be specific.]
+
+### Issues
+
+#### Critical (Must Fix)
+[Bugs, security issues, data loss risks, broken functionality]
+
+#### Important (Should Fix)
+[Architecture problems, missing features, poor error handling, test gaps]
+
+#### Minor (Nice to Have)
+[Code style, optimization opportunities, documentation improvements]
+
+**For each issue:**
+- File:line reference
+- What's wrong
+- Why it matters
+- How to fix (if not obvious)
+
+### Recommendations
+[Improvements for code quality, architecture, or process]
+
+### Assessment
+
+**Ready to merge?** [Yes/No/With fixes]
+
+**Reasoning:** [Technical assessment in 1-2 sentences]
+
+## Critical Rules
+
+**DO:**
+- Categorize by actual severity (not everything is Critical)
+- Be specific (file:line, not vague)
+- Explain WHY issues matter
+- Acknowledge strengths
+- Give clear verdict
+
+**DON'T:**
+- Say "looks good" without checking
+- Mark nitpicks as Critical
+- Give feedback on code you didn't review
+- Be vague ("improve error handling")
+- Avoid giving a clear verdict
+
+## Example Output
+
+```
+### Strengths
+- Clean database schema with proper migrations (db.ts:15-42)
+- Comprehensive test coverage (18 tests, all edge cases)
+- Good error handling with fallbacks (summarizer.ts:85-92)
+
+### Issues
+
+#### Important
+1. **Missing help text in CLI wrapper**
+   - File: index-conversations:1-31
+   - Issue: No --help flag, users won't discover --concurrency
+   - Fix: Add --help case with usage examples
+
+2. **Date validation missing**
+   - File: search.ts:25-27
+   - Issue: Invalid dates silently return no results
+   - Fix: Validate ISO format, throw error with example
+
+#### Minor
+1. **Progress indicators**
+   - File: indexer.ts:130
+   - Issue: No "X of Y" counter for long operations
+   - Impact: Users don't know how long to wait
+
+### Recommendations
+- Add progress reporting for user experience
+- Consider config file for excluded projects (portability)
+
+### Assessment
+
+**Ready to merge: With fixes**
+
+**Reasoning:** Core implementation is solid with good architecture and tests. Important issues (help text, date validation) are easily fixed and don't affect core functionality.
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,4 @@
-Use `bun run typecheck` for type checking. Typecheck runs `tsgo --noEmit`; emit (when needed) goes through `bun build`. Bun is the runtime.
+Use `bun run typecheck` for type checking. Typecheck runs `tsgo --noEmit`. Build emits both JS (via `bun build`) and `.d.ts` declarations (via `tsc -p tsconfig.build.json`). Bun is the runtime.
 
 Check [./CONTEXT.md](./CONTEXT.md) for terminology questions.
 

--- a/bun.lock
+++ b/bun.lock
@@ -22,10 +22,17 @@
     "packages/core": {
       "name": "@missingstudio/sanddune-core",
       "version": "0.0.0",
+      "dependencies": {
+        "effect": "^3.21.2",
+      },
     },
     "packages/sanddune": {
       "name": "@missingstudio/sanddune",
       "version": "0.0.0",
+      "dependencies": {
+        "@missingstudio/sanddune-core": "workspace:*",
+        "effect": "^3.21.2",
+      },
     },
     "packages/test-utils": {
       "name": "@missingstudio/sanddune-test-utils",
@@ -89,6 +96,8 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@turbo/darwin-64": ["@turbo/darwin-64@2.9.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-wnvOWuVWJ5EUHNKxExEWiGlTeVpLG1L0PCu5MUozyC1P2SHGiWsmpW6/yAuShH91Fa2TAHOvdCRBzriZh4j4Eg=="],
 
     "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-mA0FIPMwwN3lodDkQYaGxj6PeT7ZaN5aCEbkKn/WB+ZB9yJdVWA4J83GH7t43jqDc5dcnVluVN5UFx3plRiXhA=="],
@@ -143,11 +152,15 @@
 
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
+    "effect": ["effect@3.21.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-rXd2FGDM8KdjSIrc+mqEELo7ScW7xTVxEf1iInmPSpIde9/nyGuFM710cjTo7/EreGXiUX2MOonPpprbz2XHCg=="],
+
     "enquirer": ["enquirer@2.4.1", "", { "dependencies": { "ansi-colors": "^4.1.1", "strip-ansi": "^6.0.1" } }, "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
     "extendable-error": ["extendable-error@0.1.7", "", {}, "sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg=="],
+
+    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 
@@ -224,6 +237,8 @@
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
     "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
+
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,13 +1,31 @@
 {
   "name": "@missingstudio/sanddune-core",
   "version": "0.0.0",
-  "private": true,
   "type": "module",
   "main": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts"
   },
+  "files": [
+    "dist",
+    "src"
+  ],
   "scripts": {
+    "build": "tsc -p tsconfig.build.json && bun build src/index.ts --outdir dist --target node --format esm --packages external",
     "typecheck": "tsgo --noEmit"
+  },
+  "dependencies": {
+    "effect": "^3.21.2"
+  },
+  "publishConfig": {
+    "access": "public",
+    "main": "./dist/index.js",
+    "types": "./dist/index.d.ts",
+    "exports": {
+      ".": {
+        "types": "./dist/index.d.ts",
+        "import": "./dist/index.js"
+      }
+    }
   }
 }

--- a/packages/core/src/agent-invoker.ts
+++ b/packages/core/src/agent-invoker.ts
@@ -1,0 +1,23 @@
+import { Context, type Effect } from "effect";
+import type { AgentStreamEvent } from "./agent-provider";
+import type { CompletionSignal } from "./run";
+
+export interface AgentInvokeInput {
+  readonly prompt: string;
+  readonly iteration: number;
+}
+
+export interface AgentInvokeResult {
+  readonly events: readonly AgentStreamEvent[];
+  readonly completionSignal?: CompletionSignal;
+}
+
+export interface AgentInvokerService {
+  readonly invoke: (
+    input: AgentInvokeInput,
+  ) => Effect.Effect<AgentInvokeResult>;
+}
+
+export class AgentInvoker extends Context.Tag(
+  "@missingstudio/sanddune/AgentInvoker",
+)<AgentInvoker, AgentInvokerService>() {}

--- a/packages/core/src/agent-provider.ts
+++ b/packages/core/src/agent-provider.ts
@@ -1,0 +1,19 @@
+export type AgentStreamEvent =
+  | {
+      readonly type: "text";
+      readonly content: string;
+      readonly iteration: number;
+      readonly timestamp: number;
+    }
+  | {
+      readonly type: "toolCall";
+      readonly name: string;
+      readonly input: unknown;
+      readonly iteration: number;
+      readonly timestamp: number;
+    };
+
+export interface AgentProvider {
+  readonly name: string;
+  readonly env?: Readonly<Record<string, string>>;
+}

--- a/packages/core/src/branch-strategy.ts
+++ b/packages/core/src/branch-strategy.ts
@@ -1,0 +1,14 @@
+export type HeadBranchStrategy = { readonly type: "head" };
+export type MergeToHeadBranchStrategy = { readonly type: "merge-to-head" };
+
+export type NamedBranchStrategy = {
+  readonly type: "branch";
+  readonly branch: string;
+};
+
+export type BranchStrategy =
+  | HeadBranchStrategy
+  | MergeToHeadBranchStrategy
+  | NamedBranchStrategy;
+
+export type NonHeadBranchStrategy = Exclude<BranchStrategy, HeadBranchStrategy>;

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,0 +1,8 @@
+export class NotImplementedError extends Error {
+  readonly _tag = "NotImplementedError" as const;
+
+  constructor(symbol: string) {
+    super(`${symbol} is not implemented`);
+    this.name = "NotImplementedError";
+  }
+}

--- a/packages/core/src/hooks.ts
+++ b/packages/core/src/hooks.ts
@@ -1,0 +1,22 @@
+export interface HostHook {
+  readonly command: string;
+}
+
+export interface SandboxHook {
+  readonly command: string;
+  readonly sudo?: boolean;
+}
+
+export interface HostHooks {
+  readonly onWorktreeReady?: HostHook | readonly HostHook[];
+  readonly onSandboxReady?: HostHook | readonly HostHook[];
+}
+
+export interface InSandboxHooks {
+  readonly onSandboxReady?: SandboxHook | readonly SandboxHook[];
+}
+
+export interface SandboxHooks {
+  readonly host?: HostHooks;
+  readonly sandbox?: InSandboxHooks;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,1 +1,71 @@
-export {};
+export { NotImplementedError } from "./errors";
+export { AgentInvoker } from "./agent-invoker";
+
+export type {
+  BranchStrategy,
+  HeadBranchStrategy,
+  MergeToHeadBranchStrategy,
+  NamedBranchStrategy,
+  NonHeadBranchStrategy,
+} from "./branch-strategy";
+
+export type {
+  AgentInvokeInput,
+  AgentInvokeResult,
+  AgentInvokerService,
+} from "./agent-invoker";
+
+export type { AgentProvider, AgentStreamEvent } from "./agent-provider";
+
+export type {
+  AllowedBranchStrategy,
+  BindMountSandboxHandle,
+  BindMountSandboxProvider,
+  CreateSandboxProvider,
+  ExecResult,
+  InteractiveSandboxProvider,
+  IsolatedSandboxHandle,
+  IsolatedSandboxProvider,
+  NoSandboxProvider,
+  RunSandboxProvider,
+  SandboxKind,
+  SandboxProvider,
+} from "./sandbox-provider";
+
+export type {
+  HostHook,
+  HostHooks,
+  InSandboxHooks,
+  SandboxHook,
+  SandboxHooks,
+} from "./hooks";
+
+export type { Timeouts } from "./timeouts";
+export type { LoggingOption } from "./logging";
+export type { PromptArgs, PromptOption } from "./prompt";
+
+export type {
+  CompletionSignal,
+  CopyToWorktree,
+  IterationResult,
+  IterationUsage,
+  RunOptions,
+  RunResult,
+} from "./run";
+
+export type {
+  CloseResult,
+  CreateSandboxOptions,
+  Sandbox,
+  SandboxRunOptions,
+} from "./sandbox";
+
+export type {
+  CreateWorktreeOptions,
+  Worktree,
+  WorktreeCreateSandboxOptions,
+  WorktreeInteractiveOptions,
+  WorktreeRunOptions,
+} from "./worktree";
+
+export type { InteractiveOptions } from "./interactive";

--- a/packages/core/src/interactive.ts
+++ b/packages/core/src/interactive.ts
@@ -1,0 +1,18 @@
+import type { AgentProvider } from "./agent-provider";
+import type { SandboxHooks } from "./hooks";
+import type { PromptOption } from "./prompt";
+import type { InteractiveSandboxProvider } from "./sandbox-provider";
+import type { Timeouts } from "./timeouts";
+import type { CopyToWorktree } from "./run";
+
+export type InteractiveOptions<
+  S extends InteractiveSandboxProvider = InteractiveSandboxProvider,
+> = PromptOption & {
+  readonly agent: AgentProvider;
+  readonly sandbox: S;
+  readonly cwd?: string;
+  readonly env?: Readonly<Record<string, string>>;
+  readonly hooks?: SandboxHooks;
+  readonly timeouts?: Timeouts;
+  readonly copyToWorktree?: readonly (string | CopyToWorktree)[];
+};

--- a/packages/core/src/logging.ts
+++ b/packages/core/src/logging.ts
@@ -1,0 +1,8 @@
+import type { AgentStreamEvent } from "./agent-provider";
+
+export type LoggingOption =
+  | {
+      readonly type: "file";
+      readonly onAgentStreamEvent?: (event: AgentStreamEvent) => void;
+    }
+  | { readonly type: "stdout" };

--- a/packages/core/src/prompt.ts
+++ b/packages/core/src/prompt.ts
@@ -1,0 +1,13 @@
+export type PromptArgs = Readonly<Record<string, string | number>>;
+
+export type PromptOption =
+  | {
+      readonly prompt: string;
+      readonly promptFile?: never;
+      readonly promptArgs?: never;
+    }
+  | {
+      readonly prompt?: never;
+      readonly promptFile: string;
+      readonly promptArgs?: PromptArgs;
+    };

--- a/packages/core/src/run.ts
+++ b/packages/core/src/run.ts
@@ -1,0 +1,57 @@
+import type { AgentProvider } from "./agent-provider";
+import type { SandboxHooks } from "./hooks";
+import type { LoggingOption } from "./logging";
+import type { PromptOption } from "./prompt";
+import type {
+  AllowedBranchStrategy,
+  RunSandboxProvider,
+} from "./sandbox-provider";
+import type { Timeouts } from "./timeouts";
+
+export interface CopyToWorktree {
+  readonly source: string;
+  readonly destination?: string;
+}
+
+export type CompletionSignal = string;
+
+export interface IterationUsage {
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheCreationTokens?: number;
+  readonly cacheReadTokens?: number;
+}
+
+export interface IterationResult {
+  readonly iteration: number;
+  readonly commitSha?: string;
+  readonly sessionFilePath?: string;
+  readonly usage?: IterationUsage;
+  readonly completionSignal?: CompletionSignal;
+}
+
+export interface RunResult {
+  readonly sourceBranch: string;
+  readonly targetBranch: string;
+  readonly worktreePath?: string;
+  readonly iterations: readonly IterationResult[];
+  readonly commits: readonly string[];
+  readonly completionSignal?: CompletionSignal;
+}
+
+export type RunOptions<S extends RunSandboxProvider = RunSandboxProvider> =
+  PromptOption & {
+    readonly agent: AgentProvider;
+    readonly sandbox: S;
+    readonly cwd?: string;
+    readonly env?: Readonly<Record<string, string>>;
+    readonly branchStrategy?: AllowedBranchStrategy<S>;
+    readonly maxIterations?: number;
+    readonly completionSignal?: string | readonly string[];
+    readonly hooks?: SandboxHooks;
+    readonly timeouts?: Timeouts;
+    readonly logging?: LoggingOption;
+    readonly signal?: AbortSignal;
+    readonly resumeSession?: string;
+    readonly copyToWorktree?: readonly (string | CopyToWorktree)[];
+  };

--- a/packages/core/src/sandbox-provider.ts
+++ b/packages/core/src/sandbox-provider.ts
@@ -1,0 +1,47 @@
+import type { BranchStrategy, NonHeadBranchStrategy } from "./branch-strategy";
+
+export interface ExecResult {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly exitCode: number;
+}
+
+export type SandboxKind = "bind-mount" | "isolated" | "no-sandbox";
+
+export interface SandboxProvider<K extends SandboxKind = SandboxKind> {
+  readonly kind: K;
+  readonly env?: Readonly<Record<string, string>>;
+}
+
+export type BindMountSandboxProvider = SandboxProvider<"bind-mount">;
+export type IsolatedSandboxProvider = SandboxProvider<"isolated">;
+export type NoSandboxProvider = SandboxProvider<"no-sandbox">;
+
+export type RunSandboxProvider =
+  | BindMountSandboxProvider
+  | IsolatedSandboxProvider;
+
+export type CreateSandboxProvider =
+  | BindMountSandboxProvider
+  | IsolatedSandboxProvider;
+
+export type InteractiveSandboxProvider = SandboxProvider;
+
+export type AllowedBranchStrategy<S extends SandboxProvider> = [S] extends [
+  IsolatedSandboxProvider,
+]
+  ? NonHeadBranchStrategy
+  : BranchStrategy;
+
+export interface BindMountSandboxHandle {
+  exec(command: string, options?: { sudo?: boolean }): Promise<ExecResult>;
+  close(): Promise<void>;
+}
+
+export interface IsolatedSandboxHandle {
+  exec(command: string, options?: { sudo?: boolean }): Promise<ExecResult>;
+  copyIn(source: string, destination: string): Promise<void>;
+  copyFileOut(source: string, destination: string): Promise<void>;
+  extractCommits(branch: string): Promise<readonly string[]>;
+  close(): Promise<void>;
+}

--- a/packages/core/src/sandbox.ts
+++ b/packages/core/src/sandbox.ts
@@ -1,0 +1,45 @@
+import type { AgentProvider } from "./agent-provider";
+import type { SandboxHooks } from "./hooks";
+import type { LoggingOption } from "./logging";
+import type { PromptOption } from "./prompt";
+import type {
+  CreateSandboxProvider,
+  ExecResult,
+} from "./sandbox-provider";
+import type { Timeouts } from "./timeouts";
+import type { CopyToWorktree, RunResult } from "./run";
+
+export interface CreateSandboxOptions<
+  S extends CreateSandboxProvider = CreateSandboxProvider,
+> {
+  readonly agent: AgentProvider;
+  readonly sandbox: S;
+  readonly branch: string;
+  readonly cwd?: string;
+  readonly env?: Readonly<Record<string, string>>;
+  readonly hooks?: SandboxHooks;
+  readonly timeouts?: Timeouts;
+  readonly logging?: LoggingOption;
+  readonly copyToWorktree?: readonly (string | CopyToWorktree)[];
+}
+
+export type SandboxRunOptions = PromptOption & {
+  readonly maxIterations?: number;
+  readonly completionSignal?: string | readonly string[];
+  readonly env?: Readonly<Record<string, string>>;
+  readonly logging?: LoggingOption;
+  readonly signal?: AbortSignal;
+};
+
+export interface CloseResult {
+  readonly worktreePreserved: boolean;
+  readonly worktreePath?: string;
+}
+
+export interface Sandbox {
+  readonly branch: string;
+  readonly worktreePath: string;
+  run(options: SandboxRunOptions): Promise<RunResult>;
+  exec(command: string, options?: { sudo?: boolean }): Promise<ExecResult>;
+  close(): Promise<CloseResult>;
+}

--- a/packages/core/src/timeouts.ts
+++ b/packages/core/src/timeouts.ts
@@ -1,0 +1,4 @@
+export interface Timeouts {
+  readonly idleSeconds?: number;
+  readonly totalSeconds?: number;
+}

--- a/packages/core/src/worktree.ts
+++ b/packages/core/src/worktree.ts
@@ -1,0 +1,66 @@
+import type { AgentProvider } from "./agent-provider";
+import type { NonHeadBranchStrategy } from "./branch-strategy";
+import type { SandboxHooks } from "./hooks";
+import type { LoggingOption } from "./logging";
+import type { PromptOption } from "./prompt";
+import type {
+  CreateSandboxProvider,
+  InteractiveSandboxProvider,
+  RunSandboxProvider,
+} from "./sandbox-provider";
+import type { Timeouts } from "./timeouts";
+import type { CopyToWorktree, RunResult } from "./run";
+import type { Sandbox } from "./sandbox";
+
+export interface CreateWorktreeOptions {
+  readonly cwd?: string;
+  readonly branchStrategy?: NonHeadBranchStrategy;
+}
+
+export type WorktreeRunOptions<
+  S extends RunSandboxProvider = RunSandboxProvider,
+> = PromptOption & {
+  readonly agent: AgentProvider;
+  readonly sandbox: S;
+  readonly env?: Readonly<Record<string, string>>;
+  readonly maxIterations?: number;
+  readonly completionSignal?: string | readonly string[];
+  readonly hooks?: SandboxHooks;
+  readonly timeouts?: Timeouts;
+  readonly logging?: LoggingOption;
+  readonly signal?: AbortSignal;
+  readonly copyToWorktree?: readonly (string | CopyToWorktree)[];
+};
+
+export type WorktreeInteractiveOptions<
+  S extends InteractiveSandboxProvider = InteractiveSandboxProvider,
+> = PromptOption & {
+  readonly agent: AgentProvider;
+  readonly sandbox: S;
+  readonly env?: Readonly<Record<string, string>>;
+  readonly hooks?: SandboxHooks;
+  readonly timeouts?: Timeouts;
+  readonly copyToWorktree?: readonly (string | CopyToWorktree)[];
+};
+
+export interface WorktreeCreateSandboxOptions<
+  S extends CreateSandboxProvider = CreateSandboxProvider,
+> {
+  readonly agent: AgentProvider;
+  readonly sandbox: S;
+  readonly env?: Readonly<Record<string, string>>;
+  readonly hooks?: SandboxHooks;
+  readonly timeouts?: Timeouts;
+  readonly logging?: LoggingOption;
+  readonly copyToWorktree?: readonly (string | CopyToWorktree)[];
+}
+
+export interface Worktree {
+  readonly path: string;
+  readonly branch: string;
+  readonly branchStrategy: NonHeadBranchStrategy;
+  run(options: WorktreeRunOptions): Promise<RunResult>;
+  interactive(options: WorktreeInteractiveOptions): Promise<void>;
+  createSandbox(options: WorktreeCreateSandboxOptions): Promise<Sandbox>;
+  close(): Promise<void>;
+}

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts"]
+}

--- a/packages/sanddune/package.json
+++ b/packages/sanddune/package.json
@@ -9,27 +9,36 @@
   ],
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     },
     "./sandboxes/docker": {
+      "types": "./dist/sandboxes/docker.d.ts",
       "import": "./dist/sandboxes/docker.js"
     },
     "./sandboxes/podman": {
+      "types": "./dist/sandboxes/podman.d.ts",
       "import": "./dist/sandboxes/podman.js"
     },
     "./sandboxes/vercel": {
+      "types": "./dist/sandboxes/vercel.d.ts",
       "import": "./dist/sandboxes/vercel.js"
     },
     "./sandboxes/no-sandbox": {
+      "types": "./dist/sandboxes/no-sandbox.d.ts",
       "import": "./dist/sandboxes/no-sandbox.js"
     }
   },
   "scripts": {
-    "build": "bun build src/index.ts src/sandboxes/docker.ts src/sandboxes/podman.ts src/sandboxes/vercel.ts src/sandboxes/no-sandbox.ts --outdir dist --target node --format esm --packages external",
+    "build": "tsc -p tsconfig.build.json && bun build src/index.ts src/sandboxes/docker.ts src/sandboxes/podman.ts src/sandboxes/vercel.ts src/sandboxes/no-sandbox.ts --outdir dist --target node --format esm --packages external",
     "typecheck": "tsgo --noEmit",
     "test": "bun test"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@missingstudio/sanddune-core": "workspace:*",
+    "effect": "^3.21.2"
   }
 }

--- a/packages/sanddune/src/index.test.ts
+++ b/packages/sanddune/src/index.test.ts
@@ -1,5 +1,62 @@
-import { expect, test } from "bun:test";
+import { describe, expect, test } from "bun:test";
+import { NotImplementedError } from "@missingstudio/sanddune-core";
+import {
+  createSandbox,
+  createWorktree,
+  interactive,
+  run,
+} from "./index";
+import { docker } from "./sandboxes/docker";
+import { noSandbox } from "./sandboxes/no-sandbox";
+import { podman } from "./sandboxes/podman";
+import { vercel } from "./sandboxes/vercel";
 
-test("scaffold sentinel", () => {
-  expect(true).toBe(true);
+describe("entry-point stubs throw NotImplementedError", () => {
+  test("run", () => {
+    expect(() => run({} as never)).toThrow(NotImplementedError);
+    expect(() => run({} as never)).toThrow(/^run is not implemented$/);
+  });
+
+  test("createSandbox", () => {
+    expect(() => createSandbox({} as never)).toThrow(NotImplementedError);
+    expect(() => createSandbox({} as never)).toThrow(
+      /^createSandbox is not implemented$/,
+    );
+  });
+
+  test("createWorktree", () => {
+    expect(() => createWorktree()).toThrow(NotImplementedError);
+    expect(() => createWorktree()).toThrow(
+      /^createWorktree is not implemented$/,
+    );
+  });
+
+  test("interactive", () => {
+    expect(() => interactive({} as never)).toThrow(NotImplementedError);
+    expect(() => interactive({} as never)).toThrow(
+      /^interactive is not implemented$/,
+    );
+  });
+});
+
+describe("sandbox provider factories throw NotImplementedError", () => {
+  test("docker", () => {
+    expect(() => docker()).toThrow(NotImplementedError);
+    expect(() => docker()).toThrow(/^docker is not implemented$/);
+  });
+
+  test("podman", () => {
+    expect(() => podman()).toThrow(NotImplementedError);
+    expect(() => podman()).toThrow(/^podman is not implemented$/);
+  });
+
+  test("vercel", () => {
+    expect(() => vercel()).toThrow(NotImplementedError);
+    expect(() => vercel()).toThrow(/^vercel is not implemented$/);
+  });
+
+  test("noSandbox", () => {
+    expect(() => noSandbox()).toThrow(NotImplementedError);
+    expect(() => noSandbox()).toThrow(/^noSandbox is not implemented$/);
+  });
 });

--- a/packages/sanddune/src/index.ts
+++ b/packages/sanddune/src/index.ts
@@ -1,1 +1,39 @@
-export {};
+import { NotImplementedError } from "@missingstudio/sanddune-core";
+import type {
+  CreateSandboxOptions,
+  CreateSandboxProvider,
+  CreateWorktreeOptions,
+  InteractiveOptions,
+  InteractiveSandboxProvider,
+  RunOptions,
+  RunResult,
+  RunSandboxProvider,
+  Sandbox,
+  Worktree,
+} from "@missingstudio/sanddune-core";
+
+export * from "@missingstudio/sanddune-core";
+
+export function run<S extends RunSandboxProvider>(
+  _options: RunOptions<S>,
+): Promise<RunResult> {
+  throw new NotImplementedError("run");
+}
+
+export function createSandbox<S extends CreateSandboxProvider>(
+  _options: CreateSandboxOptions<S>,
+): Promise<Sandbox> {
+  throw new NotImplementedError("createSandbox");
+}
+
+export function createWorktree(
+  _options?: CreateWorktreeOptions,
+): Promise<Worktree> {
+  throw new NotImplementedError("createWorktree");
+}
+
+export function interactive<S extends InteractiveSandboxProvider>(
+  _options: InteractiveOptions<S>,
+): Promise<void> {
+  throw new NotImplementedError("interactive");
+}

--- a/packages/sanddune/src/sandboxes/docker.ts
+++ b/packages/sanddune/src/sandboxes/docker.ts
@@ -1,1 +1,13 @@
-export {};
+import {
+  NotImplementedError,
+  type BindMountSandboxProvider,
+} from "@missingstudio/sanddune-core";
+
+export interface DockerOptions {
+  readonly image?: string;
+  readonly env?: Readonly<Record<string, string>>;
+}
+
+export function docker(_options?: DockerOptions): BindMountSandboxProvider {
+  throw new NotImplementedError("docker");
+}

--- a/packages/sanddune/src/sandboxes/no-sandbox.ts
+++ b/packages/sanddune/src/sandboxes/no-sandbox.ts
@@ -1,1 +1,12 @@
-export {};
+import {
+  NotImplementedError,
+  type NoSandboxProvider,
+} from "@missingstudio/sanddune-core";
+
+export interface NoSandboxOptions {
+  readonly env?: Readonly<Record<string, string>>;
+}
+
+export function noSandbox(_options?: NoSandboxOptions): NoSandboxProvider {
+  throw new NotImplementedError("noSandbox");
+}

--- a/packages/sanddune/src/sandboxes/podman.ts
+++ b/packages/sanddune/src/sandboxes/podman.ts
@@ -1,1 +1,13 @@
-export {};
+import {
+  NotImplementedError,
+  type BindMountSandboxProvider,
+} from "@missingstudio/sanddune-core";
+
+export interface PodmanOptions {
+  readonly image?: string;
+  readonly env?: Readonly<Record<string, string>>;
+}
+
+export function podman(_options?: PodmanOptions): BindMountSandboxProvider {
+  throw new NotImplementedError("podman");
+}

--- a/packages/sanddune/src/sandboxes/vercel.ts
+++ b/packages/sanddune/src/sandboxes/vercel.ts
@@ -1,1 +1,13 @@
-export {};
+import {
+  NotImplementedError,
+  type IsolatedSandboxProvider,
+} from "@missingstudio/sanddune-core";
+
+export interface VercelOptions {
+  readonly image?: string;
+  readonly env?: Readonly<Record<string, string>>;
+}
+
+export function vercel(_options?: VercelOptions): IsolatedSandboxProvider {
+  throw new NotImplementedError("vercel");
+}

--- a/packages/sanddune/src/types.test.ts
+++ b/packages/sanddune/src/types.test.ts
@@ -1,0 +1,107 @@
+// The real assertions in this file are the @ts-expect-error directives inside
+// _typeChecks. They're checked by `bun run typecheck`, not by `bun test` —
+// the test runner only confirms the file loads. Removing this file from the
+// typecheck flow would silently drop coverage of all six type-level
+// rejections.
+import { expect, test } from "bun:test";
+import type {
+  AgentProvider,
+  BindMountSandboxProvider,
+  IsolatedSandboxProvider,
+  NoSandboxProvider,
+} from "@missingstudio/sanddune-core";
+import {
+  createSandbox,
+  createWorktree,
+  interactive,
+  run,
+} from "./index";
+import { docker } from "./sandboxes/docker";
+import { noSandbox } from "./sandboxes/no-sandbox";
+import { vercel } from "./sandboxes/vercel";
+
+test("type-level rejections are compile errors (see _typeChecks)", () => {
+  expect(typeof _typeChecks).toBe("function");
+});
+
+function _typeChecks() {
+  // Stubs typed at the parameter type — never executed at runtime because
+  // _typeChecks is never called.
+  const agentStub = null as unknown as AgentProvider;
+  const bindMountStub = null as unknown as BindMountSandboxProvider;
+  const isolatedStub = null as unknown as IsolatedSandboxProvider;
+  const noSandboxStub = null as unknown as NoSandboxProvider;
+
+  void run({
+    agent: agentStub,
+    sandbox: vercel(),
+    prompt: "x",
+    // @ts-expect-error head branch strategy is not allowed with an isolated provider
+    branchStrategy: { type: "head" },
+  });
+
+  void run({
+    agent: agentStub,
+    // @ts-expect-error noSandbox() is not allowed for run()
+    sandbox: noSandbox(),
+    prompt: "x",
+  });
+
+  void createSandbox({
+    agent: agentStub,
+    // @ts-expect-error noSandbox() is not allowed for createSandbox()
+    sandbox: noSandbox(),
+    branch: "feat/x",
+  });
+
+  void createWorktree({
+    // @ts-expect-error head branch strategy is not allowed for createWorktree()
+    branchStrategy: { type: "head" },
+  });
+
+  // @ts-expect-error prompt and promptFile are mutually exclusive
+  void run({
+    agent: agentStub,
+    sandbox: docker(),
+    prompt: "x",
+    promptFile: "y",
+  });
+
+  // @ts-expect-error promptArgs is not allowed with an inline prompt
+  void run({
+    agent: agentStub,
+    sandbox: docker(),
+    prompt: "x",
+    promptArgs: { K: "v" },
+  });
+
+  // Positive cases — must continue to compile.
+  void interactive({
+    agent: agentStub,
+    sandbox: noSandboxStub,
+    prompt: "x",
+  });
+
+  void run({
+    agent: agentStub,
+    sandbox: bindMountStub,
+    prompt: "x",
+    branchStrategy: { type: "head" },
+  });
+
+  void run({
+    agent: agentStub,
+    sandbox: bindMountStub,
+    prompt: "x",
+    branchStrategy: { type: "merge-to-head" },
+  });
+
+  void run({
+    agent: agentStub,
+    sandbox: isolatedStub,
+    prompt: "x",
+    branchStrategy: { type: "branch", branch: "feat/x" },
+  });
+}
+
+void _typeChecks;

--- a/packages/sanddune/tsconfig.build.json
+++ b/packages/sanddune/tsconfig.build.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["**/*.test.ts"]
+}


### PR DESCRIPTION
## Summary

Lock the public type surface and entry-point stubs per issue #3. No runtime behaviour — every entry point and sandbox provider factory throws `NotImplementedError`. The type surface locks architectural decisions so every later slice composes against settled types.

- **Types** in `@missingstudio/sanddune-core` (split across 13 files by concern: errors, branch-strategy, sandbox-provider, agent-provider, agent-invoker, hooks, prompt, run, sandbox, worktree, interactive, timeouts, logging).
- **Entry points** `run`, `createSandbox`, `createWorktree`, `interactive` in `@missingstudio/sanddune` — all throw `NotImplementedError` with the function name in the message.
- **Provider factories** under `./sandboxes/{docker,podman,vercel,no-sandbox}` return the correct provider variant (BindMount / Isolated / NoSandbox) at the type level; calling them throws `NotImplementedError`.
- **Effect dependency** wired; `AgentInvoker` declared as a `Context.Tag`.
- **Type-level rejections** enforced as compile errors:
  - `vercel() + branchStrategy: { type: "head" }`
  - `noSandbox()` passed to `run()`
  - `noSandbox()` passed to `createSandbox()`
  - `head` strategy passed to `createWorktree()`
  - `prompt` and `promptFile` together
  - `prompt` and `promptArgs` together
- **Build pipeline** emits `.d.ts` declarations via `tsc -p tsconfig.build.json` ahead of `bun build`. `@missingstudio/sanddune-core` is now publishable so consumers can resolve the cross-package types.

Closes #3.

## Notes

- Negative type tests use `@ts-expect-error` directives rather than `expect-type` / `tsd`. The directives serve the same purpose (an unused directive is itself a type error) without an extra devDep, and read more naturally for purely-negative cases.
- Vocabulary follows `CONTEXT.md` — no "workspace", no "worktree mode", no retired terms.

## Test plan

- [x] `bun run typecheck` — passes across all 4 packages
- [x] `bun run test` — 9 pass / 0 fail (4 entry-point stubs × throws NotImplementedError, 4 provider factories × throws NotImplementedError, 1 type-level no-op)
- [x] `bun run build` — produces 5 `.js` entry points and 19 `.d.ts` files across `@missingstudio/sanddune` + `@missingstudio/sanddune-core`
- [x] Removing any `@ts-expect-error` directive locally fires a real `tsgo` error (each directive is load-bearing)
- [x] Vocabulary scan — no occurrences of "workspace", "worktree mode", "branch mode", "local provider", "container hook", "RALPH"

🤖 Generated with [Claude Code](https://claude.com/claude-code)