### PR TITLE
feat: collapse RunResult source/target into single `branch` field (#30)

### DIFF
--- a/.changeset/run-result-single-branch.md
+++ b/.changeset/run-result-single-branch.md
@@ -1,0 +1,14 @@
+---
+"@missingstudio/sanddune": patch
+"@missingstudio/sanddune-core": patch
+---
+
+Collapse `RunResult.sourceBranch` and `RunResult.targetBranch` into a single `RunResult.branch` field that always answers "where this run's commits live after completion" (per [ADR-0013](docs/adr/0013-run-result-single-branch.md)):
+
+- `head` → `result.branch` is the host's HEAD at `run()` time
+- `merge-to-head` → `result.branch` is the host's HEAD at `run()` time (the merge target, after the fast-forward back from the temp branch)
+- `branch` (named) → `result.branch` is the named branch supplied by the caller (when wired up by #6)
+
+`RunResult.worktreePath?: string` is unchanged and remains the recovery surface for the dirty `merge-to-head` case (per ADR-0003). The internal `WorktreeStrategy` and `WorktreePlan` types still carry the `sourceBranch`/`targetBranch` distinction — `merge-to-head` mechanics need both — and the `{{SOURCE_BRANCH}}` / `{{TARGET_BRANCH}}` built-in prompt arguments are unaffected.
+
+**Breaking:** callers reading `result.sourceBranch` or `result.targetBranch` migrate to `result.branch`. For the dirty `merge-to-head` case, the preserved temp branch name is no longer surfaced on the result; recover it via `cd $result.worktreePath && git symbolic-ref --short HEAD`.

--- a/.sanddune/docker-head-claude-code.ts
+++ b/.sanddune/docker-head-claude-code.ts
@@ -14,8 +14,7 @@ const result = await run({
 
 console.log("\nrun complete");
 
-console.log(`  source branch: ${result.sourceBranch}`);
-console.log(`  target branch: ${result.targetBranch}`);
+console.log(`  branch:        ${result.branch}`);
 console.log(`  iterations:    ${result.iterations.length}`);
 console.log(`  commits:       ${result.commits.length}`);
 

--- a/.sanddune/docker-head-shell.ts
+++ b/.sanddune/docker-head-shell.ts
@@ -46,8 +46,7 @@ const result = await run({
 const headAfter = git("rev-parse", "HEAD");
 
 console.log("\nrun complete");
-console.log(`  source branch:    ${result.sourceBranch}`);
-console.log(`  target branch:    ${result.targetBranch}`);
+console.log(`  branch:           ${result.branch}`);
 console.log(`  iterations:       ${result.iterations.length}`);
 console.log(`  commits:          ${result.commits.length}`);
 for (const sha of result.commits) console.log(`    ${sha}`);
@@ -70,14 +69,9 @@ if (headAfter === headBefore) {
 if (!existsSync(resolve("HEAD-SHELL.md"))) {
   failures.push("HEAD-SHELL.md is not on the host working tree");
 }
-if (result.sourceBranch !== branchBefore) {
+if (result.branch !== branchBefore) {
   failures.push(
-    `expected sourceBranch == host branch (${branchBefore}), got ${result.sourceBranch}`,
-  );
-}
-if (result.targetBranch !== branchBefore) {
-  failures.push(
-    `expected targetBranch == host branch (${branchBefore}), got ${result.targetBranch}`,
+    `expected branch == host branch (${branchBefore}), got ${result.branch}`,
   );
 }
 

--- a/.sanddune/docker-merge-to-head-claude-code.ts
+++ b/.sanddune/docker-merge-to-head-claude-code.ts
@@ -35,8 +35,7 @@ const result = await run({
 
 const headAfter = git("rev-parse", "HEAD");
 console.log("\nrun complete");
-console.log(`  source branch:   ${result.sourceBranch}`);
-console.log(`  target branch:   ${result.targetBranch}`);
+console.log(`  branch:          ${result.branch}`);
 console.log(`  iterations:      ${result.iterations.length}`);
 console.log(`  commits:         ${result.commits.length}`);
 for (const sha of result.commits) console.log(`    ${sha}`);

--- a/.sanddune/docker-merge-to-head-shell.ts
+++ b/.sanddune/docker-merge-to-head-shell.ts
@@ -46,8 +46,7 @@ const result = await run({
 const headAfter = git("rev-parse", "HEAD");
 
 console.log("\nrun complete");
-console.log(`  source branch:    ${result.sourceBranch}`);
-console.log(`  target branch:    ${result.targetBranch}`);
+console.log(`  branch:           ${result.branch}`);
 console.log(`  iterations:       ${result.iterations.length}`);
 console.log(`  commits:          ${result.commits.length}`);
 for (const sha of result.commits) console.log(`    ${sha}`);

--- a/README.md
+++ b/README.md
@@ -691,7 +691,8 @@ Removes the Podman image.
 | `completionSignal` | string?             | The matched completion signal string, or `undefined` if none fired |
 | `stdout`           | string              | Agent output                                                       |
 | `commits`          | `{ sha }[]`         | Commits created during the run                                     |
-| `branch`           | string              | Target branch name                                                 |
+| `branch`           | string              | Branch where the run's commits live after completion. For `head` and `merge-to-head`, the host branch at `run()` time. For the `branch` strategy, the named branch supplied by the caller |
+| `worktreePath`     | string?             | Set when the worktree was preserved on disk after the run (e.g. dirty `merge-to-head`). Caller can `cd` here to recover leftover work |
 | `logFilePath`      | string?             | Path to the log file (only when logging to a file)                 |
 
 ### `IterationResult`

--- a/packages/core/src/run.ts
+++ b/packages/core/src/run.ts
@@ -31,8 +31,7 @@ export interface IterationResult {
 }
 
 export interface RunResult {
-  readonly sourceBranch: string;
-  readonly targetBranch: string;
+  readonly branch: string;
   readonly worktreePath?: string;
   readonly iterations: readonly IterationResult[];
   readonly commits: readonly string[];

--- a/packages/sanddune/src/internal/run-program.ts
+++ b/packages/sanddune/src/internal/run-program.ts
@@ -7,6 +7,7 @@ import {
   type RunOptions,
   type RunResult,
   type RunSandboxProvider,
+  type WorktreePlan,
 } from "@missingstudio/sanddune-core";
 import { resolveEnv } from "./env-resolver";
 import { gitCurrentBranch, gitHeadSha, gitNewCommits } from "./git";
@@ -100,8 +101,7 @@ export async function runProgram(
     const commits = await gitNewCommits(cwd, beforeSha);
 
     resultBase = {
-      sourceBranch: strategy.sourceBranch,
-      targetBranch: strategy.targetBranch,
+      branch: resultBranchFor(plan),
       iterations: loopResult.iterations,
       commits,
       stdout: loopResult.stdout,
@@ -126,6 +126,16 @@ export async function runProgram(
   return preservedPath !== undefined
     ? { ...resultBase, worktreePath: preservedPath }
     : resultBase;
+}
+
+function resultBranchFor(plan: WorktreePlan): string {
+  switch (plan.type) {
+    case "head":
+    case "merge-to-head":
+      return plan.targetBranch;
+    case "branch":
+      return plan.sourceBranch;
+  }
 }
 
 async function closeHandleSafely(

--- a/packages/sanddune/src/run.integration.test.ts
+++ b/packages/sanddune/src/run.integration.test.ts
@@ -87,8 +87,7 @@ describe("runProgram (integration)", () => {
     expect(result.iterations).toHaveLength(1);
     expect(result.commits).toHaveLength(1);
     expect(result.iterations[0]?.commitSha).toBe(result.commits[0]);
-    expect(result.sourceBranch).toBe("main");
-    expect(result.targetBranch).toBe("main");
+    expect(result.branch).toBe("main");
     expect(result.stdout).toBe("did the thing\n");
     expect(result.logFilePath).toMatch(/\.sanddune\/logs\/.+\.jsonl$/);
     expect(closeCalls).toEqual([1]);
@@ -185,10 +184,10 @@ describe("runProgram (integration)", () => {
     expect(result.commits[0]).toBe(headAfter);
     expect(headAfter).not.toBe(headBeforeRun);
 
-    // sourceBranch is the temp branch the manager created; targetBranch is
-    // the host's branch at run() time.
-    expect(result.sourceBranch).toMatch(/^sanddune\/merge-to-head\//);
-    expect(result.targetBranch).toBe("main");
+    // For merge-to-head, branch is the host branch the commits ended up on
+    // (after fast-forward back from the temp source branch). The temp branch
+    // itself is no longer surfaced on RunResult.
+    expect(result.branch).toBe("main");
 
     // Clean worktree was removed; no preservation surface on the result.
     expect(result.worktreePath).toBeUndefined();
@@ -260,8 +259,10 @@ describe("runProgram (integration)", () => {
       agentInvokerLayer: Layer.succeed(AgentInvoker, fakeInvoker),
     });
 
-    // The committed change still merged back to host HEAD.
+    // The committed change still merged back to host HEAD — branch reports
+    // where the commits landed, not the preserved temp source branch.
     expect(result.commits).toHaveLength(1);
+    expect(result.branch).toBe("main");
 
     // Worktree was preserved on disk; result surfaces the path.
     expect(result.worktreePath).toBeDefined();


### PR DESCRIPTION
## Summary

Closes #30. Implements [ADR-0013](docs/adr/0013-run-result-single-branch.md) — `RunResult.sourceBranch` / `targetBranch` collapse into a single `RunResult.branch` field that always answers "where this run's commits live after completion":

| strategy        | `RunResult.branch`                                              |
| --------------- | --------------------------------------------------------------- |
| `head`          | host's HEAD at `run()` time                                     |
| `merge-to-head` | host's HEAD at `run()` time (after the fast-forward back)       |
| `branch`        | the named branch (wired up by #6)                               |

Prerequisite for #6.

- `RunResult.worktreePath?` is unchanged — still the dirty-`merge-to-head` recovery surface
- Internal `WorktreeStrategy` and `WorktreePlan` keep their `sourceBranch` / `targetBranch` distinction (`merge-to-head` mechanics need both)
- `{{SOURCE_BRANCH}}` / `{{TARGET_BRANCH}}` prompt args are unaffected
- README's `RunResult` table also gains the previously-undocumented `worktreePath` row

**Breaking** (pre-1.0, patch changeset): callers reading `result.sourceBranch` / `result.targetBranch` migrate to `result.branch`. Dirty `merge-to-head` callers wanting the preserved temp branch name use `cd $result.worktreePath && git symbolic-ref --short HEAD`.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun test` — 65 pass, 1 skip, 0 fail
- [x] Merge-to-head clean integration test asserts `result.branch === "main"`
- [x] Merge-to-head dirty integration test asserts `result.branch === "main"` (commits still merged) and `result.worktreePath` is set to preserved path
- [x] Head integration test asserts `result.branch === "main"`
- [x] `.sanddune/` example scripts updated and compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)