### PR TITLE
feat: wire branch (named) strategy through run()

### DIFF
--- a/.changeset/branch-strategy-named.md
+++ b/.changeset/branch-strategy-named.md
@@ -1,0 +1,20 @@
+---
+"@missingstudio/sanddune": patch
+---
+
+Wire `branchStrategy: { type: "branch", branch: "<name>" }` end-to-end through `run()`. `run({ ..., branchStrategy: { type: "branch", branch: "agent/foo" } })` now creates (or reuses) a git worktree at `.sanddune/worktrees/<sanitized-name>/`, runs the agent against the named branch, and reports the named branch on `RunResult.branch`. There is no merge-back — host HEAD is untouched.
+
+Behavior:
+
+- **New branch** — when the named branch does not exist locally, sanddune creates it from host HEAD via `git worktree add -b <branch> <path> HEAD`.
+- **Existing branch, no worktree on disk** — sanddune attaches a fresh worktree onto the existing branch via `git worktree add <path> <branch>`. Commits append to the branch tip.
+- **Existing branch, worktree on disk** (typically a re-run after a dirty close) — sanddune reuses the worktree per ADR-0003: a `console.log` line for clean, a stderr warning for dirty. The agent starts with whatever state is on disk.
+- **Branch already checked out elsewhere** (e.g. host HEAD is on the named branch) — fails fast with a clear error rather than letting `git worktree add` fail opaquely.
+
+`close()` follows the same dirty-preservation policy as `merge-to-head` (ADR-0003): clean worktree → removed via `git worktree remove --force`; dirty worktree → preserved on disk and surfaced via `RunResult.worktreePath`. The named branch itself is never deleted by sanddune — that's the user's branch to keep.
+
+Worktree path derivation: branch names with `/` (the common `agent/foo` pattern) are sanitized by replacing `/` with `-` to keep the worktree as a single directory under `.sanddune/worktrees/`. Other characters allowed by git ref-name rules are already path-safe.
+
+Known limitation: branches that differ only by `/` vs `-` (e.g. `agent/foo` and `agent-foo`) collide on the same on-disk id and lock file. The collision surfaces as a fail-fast — either the worktree-already-checked-out guard, or a lock-held error naming the other branch — never as silent state sharing. If this bites, rename one of the branches.
+
+Out of scope for this slice: `createWorktree()` and `wt.*` as public entry points (#17), `interactive()` honoring non-default strategies, isolated-provider runtime, and a user-facing `pruneStale()` command for orphaned worktrees and locks.

--- a/.sanddune/README.md
+++ b/.sanddune/README.md
@@ -36,9 +36,9 @@ Sanddune reads `.sanddune/.env` at launch — no manual `source` step needed. Pe
 
 ## 4. Run sanddune
 
-There are two runnable demos, one per shipped **branch strategy**. Demo files
-follow `<sandbox>-<strategy>-<agent>.ts` so a glance at the filename tells you
-which combination it exercises.
+There are three runnable demos, one per shipped **branch strategy**. Demo
+files follow `<sandbox>-<strategy>-<agent>.ts` so a glance at the filename
+tells you which combination it exercises.
 
 ### Head (default)
 
@@ -69,6 +69,20 @@ The script:
 - removes the worktree and deletes the temp branch on a clean close; preserves both on disk if the agent left uncommitted work and surfaces the path on `RunResult.worktreePath`
 - prints `host HEAD before` / `host HEAD after` so you can see the merge happened
 
+### Branch (named)
+
+```bash
+bun .sanddune/docker-branch-claude-code.ts
+```
+
+The script:
+
+- creates (or reuses) a worktree under `.sanddune/worktrees/sanddune-branch-demo/` for the named branch `sanddune/branch-demo`
+- runs Claude Code for one iteration; the commit lands on `sanddune/branch-demo`, **not** on host HEAD — there is no merge-back
+- removes the worktree on a clean close; the named branch is preserved on disk so you can `git checkout sanddune/branch-demo` to pick it up
+- re-running the script reuses the worktree (per ADR-0003): a clean reuse logs to stdout, a dirty reuse warns to stderr; the new commit appends to the branch tip
+- prints `host HEAD before` / `host HEAD after` (should match) and the named branch's tip
+
 In another terminal you can follow the JSONL stream:
 
 ```bash
@@ -81,13 +95,18 @@ tail -f .sanddune/logs/*.jsonl
 git log -1
 ls HELLO.md                  # after docker-head-claude-code.ts
 ls MERGE-TO-HEAD-HELLO.md    # after docker-merge-to-head-claude-code.ts
+git log sanddune/branch-demo # after docker-branch-claude-code.ts
 ```
 
 If you want to roll either change back:
 
 ```bash
+# head / merge-to-head
 git reset --hard HEAD~1
 rm -f HELLO.md MERGE-TO-HEAD-HELLO.md
+
+# branch (named) — host HEAD was never touched, so just drop the branch
+git branch -D sanddune/branch-demo
 ```
 
 ## Custom image name

--- a/.sanddune/docker-branch-claude-code.ts
+++ b/.sanddune/docker-branch-claude-code.ts
@@ -1,0 +1,68 @@
+// Exercises the branch (named) strategy against real Docker.
+//
+// What it demonstrates:
+//   - The agent works in .sanddune/worktrees/<sanitized-name>/, NOT the host
+//     working tree. During the run, your host repo is untouched.
+//   - The commit lands on the named branch (`sanddune/branch-demo`). There is
+//     no merge-back — host HEAD stays put. After the run, the named branch
+//     points at the agent's commit; you can `git log sanddune/branch-demo`
+//     or `git checkout sanddune/branch-demo` to inspect or pick it up.
+//   - On a re-run with the same branch name, the worktree is reused and the
+//     new commit appends to the existing tip (per ADR-0003). Try it twice.
+//   - On a clean close, the worktree is removed; the named branch is preserved.
+//
+// Roll back when you're done:
+//   git branch -D sanddune/branch-demo
+
+import { spawnSync } from "node:child_process";
+import { run, claudeCode } from "@missingstudio/sanddune";
+import { docker } from "@missingstudio/sanddune/sandboxes/docker";
+
+const BRANCH = "sanddune/branch-demo";
+
+const headBefore = git("rev-parse", "HEAD");
+const branchBefore = git("rev-parse", "--abbrev-ref", "HEAD");
+console.log(`host before run: ${branchBefore} @ ${headBefore.slice(0, 12)}`);
+
+const result = await run({
+  agent: claudeCode("claude-opus-4-7"),
+  sandbox: docker(),
+  prompt:
+    "Create a file called BRANCH-HELLO.md at the repo root containing a single line `hello from branch strategy`. Then commit the change with the message 'add BRANCH-HELLO.md'. Stop when the commit lands.",
+  branchStrategy: { type: "branch", branch: BRANCH },
+});
+
+const headAfter = git("rev-parse", "HEAD");
+const branchTip = gitOrEmpty("rev-parse", BRANCH);
+
+console.log("\nrun complete");
+console.log(`  branch:           ${result.branch}`);
+console.log(`  iterations:       ${result.iterations.length}`);
+console.log(`  commits:          ${result.commits.length}`);
+for (const sha of result.commits) console.log(`    ${sha}`);
+console.log(`  host HEAD before: ${headBefore.slice(0, 12)}`);
+console.log(`  host HEAD after:  ${headAfter.slice(0, 12)}  (unchanged)`);
+console.log(`  ${BRANCH} tip:    ${branchTip.slice(0, 12)}`);
+
+if (result.worktreePath) {
+  console.log(`\n  worktree preserved (dirty): ${result.worktreePath}`);
+} else {
+  console.log("\n  worktree removed cleanly; named branch preserved on disk");
+}
+
+if (headAfter !== headBefore) {
+  console.log("  WARNING: host HEAD moved — branch strategy should not touch it");
+}
+
+function git(...args: string[]): string {
+  const r = spawnSync("git", args, { encoding: "utf8" });
+  if (r.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed: ${r.stderr}`);
+  }
+  return r.stdout.trim();
+}
+
+function gitOrEmpty(...args: string[]): string {
+  const r = spawnSync("git", args, { encoding: "utf8" });
+  return r.status === 0 ? r.stdout.trim() : "";
+}

--- a/packages/sanddune/src/internal/run-program.ts
+++ b/packages/sanddune/src/internal/run-program.ts
@@ -63,7 +63,13 @@ export async function runProgram(
 
   await runLog.runStarted();
 
-  const beforeSha = await gitHeadSha(cwd);
+  // Capture the pre-run tip of the ref the agent will commit to. For `head`
+  // the worktree path *is* the host cwd, so this is the host HEAD. For
+  // `merge-to-head` the worktree was just created from host HEAD, so its
+  // HEAD matches. For `branch` this is the named branch's tip (or the host
+  // HEAD it was just created from). Anything past this SHA on the worktree's
+  // HEAD after the run is the agent's contribution.
+  const beforeSha = await gitHeadSha(strategy.worktreePath);
 
   let handle: BindMountSandboxHandle | undefined;
   let resultBase: RunResult | undefined;
@@ -98,7 +104,10 @@ export async function runProgram(
     );
 
     await strategy.afterIteration();
-    const commits = await gitNewCommits(cwd, beforeSha);
+    // Read commits off the worktree's HEAD — the worktree (whether host cwd
+    // for `head`, the temp branch for `merge-to-head`, or the named branch
+    // for `branch`) is always where the agent's commits land first.
+    const commits = await gitNewCommits(strategy.worktreePath, beforeSha);
 
     resultBase = {
       branch: resultBranchFor(plan),

--- a/packages/sanddune/src/internal/worktree-manager.ts
+++ b/packages/sanddune/src/internal/worktree-manager.ts
@@ -1,7 +1,8 @@
 import { randomBytes } from "node:crypto";
-import { mkdir } from "node:fs/promises";
+import { mkdir, realpath, stat } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { runGit } from "./git-spawn";
+import { spawnHost } from "./host-process";
 import {
   acquireWorktreeLock,
   type WorktreeLockHandle,
@@ -78,6 +79,157 @@ export async function createMergeToHeadWorktree(
       }
     },
   };
+}
+
+export interface CreateBranchWorktreeOptions {
+  readonly cwd: string;
+  readonly branch: string;
+  readonly targetBranch: string;
+}
+
+export async function createBranchWorktree(
+  options: CreateBranchWorktreeOptions,
+): Promise<ManagedWorktree> {
+  const cwd = resolve(options.cwd);
+  const id = sanitizeBranchForPath(options.branch);
+  const worktreePath = join(cwd, ".sanddune", "worktrees", id);
+
+  await mkdir(dirname(worktreePath), { recursive: true });
+
+  const lock: WorktreeLockHandle = await acquireWorktreeLock({
+    cwd,
+    id,
+    branch: options.branch,
+  });
+
+  try {
+    const checkoutPath = await getWorktreePathForBranch(cwd, options.branch);
+    const sameAsOurs =
+      checkoutPath !== null && (await samePath(checkoutPath, worktreePath));
+    if (checkoutPath !== null && !sameAsOurs) {
+      throw new Error(
+        `Branch "${options.branch}" is already checked out at ${checkoutPath}; refusing to create a second worktree for it.`,
+      );
+    }
+
+    const dirExists = await pathExists(worktreePath);
+    if (sameAsOurs && dirExists) {
+      const dirty = await gitStatusIsDirty(worktreePath);
+      if (dirty) {
+        process.stderr.write(
+          `sanddune: reusing existing worktree at ${worktreePath} for branch "${options.branch}" — uncommitted changes are present and will be visible to the agent.\n`,
+        );
+      } else {
+        process.stdout.write(
+          `sanddune: reusing existing worktree at ${worktreePath} for branch "${options.branch}".\n`,
+        );
+      }
+    } else {
+      const branchExists = await gitBranchExists(cwd, options.branch);
+      if (branchExists) {
+        await runGit(cwd, ["worktree", "add", worktreePath, options.branch]);
+      } else {
+        await runGit(cwd, [
+          "worktree",
+          "add",
+          "-b",
+          options.branch,
+          worktreePath,
+          "HEAD",
+        ]);
+      }
+    }
+  } catch (err) {
+    await lock.release();
+    throw err;
+  }
+
+  let closed = false;
+  return {
+    id,
+    path: worktreePath,
+    sourceBranch: options.branch,
+    targetBranch: options.targetBranch,
+    isDirty: () => gitStatusIsDirty(worktreePath),
+    close: async () => {
+      if (closed) return { preserved: false };
+      closed = true;
+      try {
+        const dirty = await gitStatusIsDirty(worktreePath);
+        if (dirty) {
+          return { preserved: true, path: worktreePath };
+        }
+        await runGit(cwd, ["worktree", "remove", "--force", worktreePath]);
+        return { preserved: false };
+      } finally {
+        await lock.release();
+      }
+    },
+  };
+}
+
+// Branch names may contain `/`, which is unsafe as a single directory
+// segment. Replace `/` with `-` so `agent/foo` maps to a flat directory
+// `agent-foo` under `.sanddune/worktrees/`. Other ref-name characters
+// (`.`, `_`, alphanumerics, `-`) are already path-safe.
+function sanitizeBranchForPath(branch: string): string {
+  return branch.replace(/\//g, "-");
+}
+
+// `git worktree list --porcelain` reports paths with symlinks resolved
+// (e.g. macOS `/var/...` reported as `/private/var/...`). Our worktree path
+// is built with `path.join` from `options.cwd`, which preserves whatever
+// the caller passed in. Compare via `realpath` so a symlink layer doesn't
+// trick us into thinking the branch is checked out elsewhere.
+async function samePath(a: string, b: string): Promise<boolean> {
+  if (a === b) return true;
+  try {
+    const [ra, rb] = await Promise.all([realpath(a), realpath(b)]);
+    return ra === rb;
+  } catch {
+    return false;
+  }
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw err;
+  }
+}
+
+async function gitBranchExists(cwd: string, branch: string): Promise<boolean> {
+  // `git show-ref --verify` *uses* exit codes to signal "branch missing", so
+  // bypass `runGit`'s throw-on-nonzero and read the exit code directly.
+  const result = await spawnHost(
+    "git",
+    ["show-ref", "--verify", "--quiet", `refs/heads/${branch}`],
+    { cwd },
+  );
+  return result.exitCode === 0;
+}
+
+async function getWorktreePathForBranch(
+  cwd: string,
+  branch: string,
+): Promise<string | null> {
+  const result = await runGit(cwd, ["worktree", "list", "--porcelain"]);
+  const wanted = `refs/heads/${branch}`;
+  let currentPath: string | null = null;
+  for (const line of result.stdout.split("\n")) {
+    if (line.startsWith("worktree ")) {
+      currentPath = line.slice("worktree ".length);
+    } else if (line.startsWith("branch ") && currentPath) {
+      const ref = line.slice("branch ".length);
+      if (ref === wanted) return currentPath;
+    } else if (line.length === 0) {
+      currentPath = null;
+    }
+  }
+  return null;
 }
 
 function newWorktreeId(): string {

--- a/packages/sanddune/src/internal/worktree-strategy.ts
+++ b/packages/sanddune/src/internal/worktree-strategy.ts
@@ -1,6 +1,7 @@
 import type { WorktreePlan } from "@missingstudio/sanddune-core";
 import { gitBranchDelete, gitMerge } from "./git";
 import {
+  createBranchWorktree,
   createMergeToHeadWorktree,
   type ManagedWorktree,
 } from "./worktree-manager";
@@ -10,8 +11,8 @@ export interface WorktreeStrategy {
   readonly sourceBranch: string;
   readonly targetBranch: string;
   /** Run after the iteration loop succeeds and before final commit reconciliation.
-   *  No-op for `head`; fast-forwards the temp source branch back to the target
-   *  branch for `merge-to-head`. */
+   *  No-op for `head` and `branch`; fast-forwards the temp source branch back to
+   *  the target branch for `merge-to-head`. */
   afterIteration(): Promise<void>;
   /** Tears down any worktree, lock, or temp branch this strategy created.
    *  Never throws — logs to stderr and returns `{}` on internal failure. */
@@ -39,9 +40,11 @@ export async function createWorktreeStrategy(
         targetBranch: options.plan.targetBranch,
       });
     case "branch":
-      throw new Error(
-        `run() does not yet support branchStrategy: { type: "branch" } in this release.`,
-      );
+      return createNamedBranchStrategy({
+        cwd: options.cwd,
+        branch: options.plan.sourceBranch,
+        targetBranch: options.plan.targetBranch,
+      });
   }
 }
 
@@ -57,6 +60,38 @@ function createHeadStrategy(args: {
     async afterIteration() {},
     async close() {
       return {};
+    },
+  };
+}
+
+async function createNamedBranchStrategy(args: {
+  cwd: string;
+  branch: string;
+  targetBranch: string;
+}): Promise<WorktreeStrategy> {
+  const worktree: ManagedWorktree = await createBranchWorktree({
+    cwd: args.cwd,
+    branch: args.branch,
+    targetBranch: args.targetBranch,
+  });
+
+  return {
+    worktreePath: worktree.path,
+    sourceBranch: worktree.sourceBranch,
+    targetBranch: args.targetBranch,
+    async afterIteration() {},
+    async close() {
+      try {
+        const r = await worktree.close();
+        return r.preserved && r.path ? { preservedPath: r.path } : {};
+      } catch (e) {
+        process.stderr.write(
+          `sanddune: worktree teardown failed: ${
+            e instanceof Error ? e.message : String(e)
+          }\n`,
+        );
+        return {};
+      }
     },
   };
 }

--- a/packages/sanddune/src/run.integration.test.ts
+++ b/packages/sanddune/src/run.integration.test.ts
@@ -282,6 +282,268 @@ describe("runProgram (integration)", () => {
     expect(closeCalls).toEqual([1]);
   });
 
+  test("branch (named): new branch is created from HEAD and commits land on it", async () => {
+    const closeCalls: number[] = [];
+    const provider = makeLocalProcessBindMountProvider(closeCalls);
+    const agent = createAgentProvider({
+      name: "stub",
+      buildCommand: () => "true",
+      parseLine: () => [],
+    });
+
+    const handleRef: { current: BindMountSandboxHandle | undefined } = {
+      current: undefined,
+    };
+    const fakeInvoker = scriptedAgent(handleRef, [
+      "printf 'first\\n' > a.txt && git add a.txt && git -c user.email=agent@example.com -c user.name=agent -c commit.gpgsign=false commit -m 'first commit'",
+    ]);
+
+    const headBeforeRun = runSync("git", ["rev-parse", "HEAD"], repo).stdout
+      .trim();
+
+    const options: RunOptions<RunSandboxProvider> = {
+      agent,
+      sandbox: capturingProvider(provider, handleRef),
+      prompt: "do the thing",
+      cwd: repo,
+      branchStrategy: { type: "branch", branch: "agent/foo" },
+    };
+
+    const result = await runProgram(options, {
+      agentInvokerLayer: Layer.succeed(AgentInvoker, fakeInvoker.invoker),
+    });
+
+    // Branch was created from HEAD and commit lives on it.
+    expect(result.commits).toHaveLength(1);
+    expect(result.branch).toBe("agent/foo");
+
+    const branchTip = runSync("git", ["rev-parse", "agent/foo"], repo).stdout
+      .trim();
+    expect(branchTip).toBe(result.commits[0]!);
+    expect(branchTip).not.toBe(headBeforeRun);
+
+    // Host HEAD is untouched — no merge-back happened.
+    const headAfter = runSync("git", ["rev-parse", "HEAD"], repo).stdout.trim();
+    expect(headAfter).toBe(headBeforeRun);
+
+    // Worktree path uses the sanitized branch name (`/` → `-`).
+    const expectedWorktree = join(repo, ".sanddune", "worktrees", "agent-foo");
+    expect(result.worktreePath).toBeUndefined(); // clean → removed
+    expect(existsSync(expectedWorktree)).toBe(false);
+
+    // Lock released.
+    const lockEntries = runSync("ls", [join(repo, ".sanddune", "locks")], repo)
+      .stdout.trim();
+    expect(lockEntries).toBe("");
+
+    // Branch is preserved on disk — it's the user's whole reason for picking
+    // this strategy.
+    const branchList = runSync("git", ["branch", "--list"], repo).stdout;
+    expect(branchList).toMatch(/agent\/foo/);
+
+    expect(closeCalls).toEqual([1]);
+  });
+
+  test("branch (named): existing branch is reused and commits append", async () => {
+    // Pre-create the named branch with a commit on it so the run starts from
+    // an existing tip.
+    runSync("git", ["branch", "agent/bar"], repo);
+    runSync("git", ["worktree", "add", join(repo, "tmp-seed"), "agent/bar"], repo);
+    await writeFile(join(repo, "tmp-seed", "seeded.txt"), "seeded\n");
+    runSync("git", ["add", "seeded.txt"], join(repo, "tmp-seed"));
+    runSync(
+      "git",
+      [
+        "-c",
+        "user.email=seed@example.com",
+        "-c",
+        "user.name=seed",
+        "commit",
+        "-m",
+        "seed on branch",
+      ],
+      join(repo, "tmp-seed"),
+    );
+    const seedTip = runSync("git", ["rev-parse", "agent/bar"], repo).stdout
+      .trim();
+    runSync("git", ["worktree", "remove", "--force", join(repo, "tmp-seed")], repo);
+
+    const closeCalls: number[] = [];
+    const provider = makeLocalProcessBindMountProvider(closeCalls);
+    const agent = createAgentProvider({
+      name: "stub",
+      buildCommand: () => "true",
+      parseLine: () => [],
+    });
+
+    const handleRef: { current: BindMountSandboxHandle | undefined } = {
+      current: undefined,
+    };
+    const fakeInvoker = scriptedAgent(handleRef, [
+      "printf 'appended\\n' > appended.txt && git add appended.txt && git -c user.email=agent@example.com -c user.name=agent -c commit.gpgsign=false commit -m 'append'",
+    ]);
+
+    const result = await runProgram(
+      {
+        agent,
+        sandbox: capturingProvider(provider, handleRef),
+        prompt: "append a commit",
+        cwd: repo,
+        branchStrategy: { type: "branch", branch: "agent/bar" },
+      },
+      {
+        agentInvokerLayer: Layer.succeed(AgentInvoker, fakeInvoker.invoker),
+      },
+    );
+
+    expect(result.branch).toBe("agent/bar");
+    expect(result.commits).toHaveLength(1);
+
+    // The new commit was appended onto the existing branch tip, not built on
+    // host HEAD.
+    const newTip = runSync("git", ["rev-parse", "agent/bar"], repo).stdout
+      .trim();
+    expect(newTip).toBe(result.commits[0]!);
+    const parent = runSync("git", ["rev-parse", "agent/bar^"], repo).stdout
+      .trim();
+    expect(parent).toBe(seedTip);
+
+    expect(closeCalls).toEqual([1]);
+  });
+
+  test("branch (named): dirty worktree is preserved and reused on the next run", async () => {
+    const closeCalls1: number[] = [];
+    const provider1 = makeLocalProcessBindMountProvider(closeCalls1);
+    const agent = createAgentProvider({
+      name: "stub",
+      buildCommand: () => "true",
+      parseLine: () => [],
+    });
+
+    const handleRef1: { current: BindMountSandboxHandle | undefined } = {
+      current: undefined,
+    };
+    // First run: commit one file, leave another uncommitted to dirty the worktree.
+    const fakeInvoker1 = scriptedAgent(handleRef1, [
+      "printf 'committed\\n' > committed.txt && git add committed.txt && git -c user.email=agent@example.com -c user.name=agent -c commit.gpgsign=false commit -m 'first' && printf 'leftover\\n' > leftover.txt",
+    ]);
+
+    const firstResult = await runProgram(
+      {
+        agent,
+        sandbox: capturingProvider(provider1, handleRef1),
+        prompt: "leave a mess",
+        cwd: repo,
+        branchStrategy: { type: "branch", branch: "agent/baz" },
+      },
+      {
+        agentInvokerLayer: Layer.succeed(AgentInvoker, fakeInvoker1.invoker),
+      },
+    );
+
+    expect(firstResult.branch).toBe("agent/baz");
+    expect(firstResult.commits).toHaveLength(1);
+    // Dirty → preserved on disk.
+    expect(firstResult.worktreePath).toBeDefined();
+    const preserved = firstResult.worktreePath!;
+    expect(existsSync(preserved)).toBe(true);
+    expect(existsSync(join(preserved, "leftover.txt"))).toBe(true);
+    // Lock released even though worktree preserved.
+    expect(
+      runSync("ls", [join(repo, ".sanddune", "locks")], repo).stdout.trim(),
+    ).toBe("");
+
+    // Second run on the same branch: worktree is reused — including the
+    // leftover uncommitted file. Agent commits that file this time.
+    const closeCalls2: number[] = [];
+    const provider2 = makeLocalProcessBindMountProvider(closeCalls2);
+    const handleRef2: { current: BindMountSandboxHandle | undefined } = {
+      current: undefined,
+    };
+    const fakeInvoker2 = scriptedAgent(handleRef2, [
+      "test -f leftover.txt && git add leftover.txt && git -c user.email=agent@example.com -c user.name=agent -c commit.gpgsign=false commit -m 'cleaned up leftover'",
+    ]);
+
+    const secondResult = await runProgram(
+      {
+        agent,
+        sandbox: capturingProvider(provider2, handleRef2),
+        prompt: "finish what you started",
+        cwd: repo,
+        branchStrategy: { type: "branch", branch: "agent/baz" },
+      },
+      {
+        agentInvokerLayer: Layer.succeed(AgentInvoker, fakeInvoker2.invoker),
+      },
+    );
+
+    expect(secondResult.branch).toBe("agent/baz");
+    // The cleanup commit is the only new commit since the second run started.
+    expect(secondResult.commits).toHaveLength(1);
+    // After a clean close on the second run, the worktree is removed again.
+    expect(secondResult.worktreePath).toBeUndefined();
+    expect(existsSync(preserved)).toBe(false);
+
+    // Branch tip now has both commits.
+    const branchLog = runSync(
+      "git",
+      ["log", "agent/baz", "--format=%s"],
+      repo,
+    ).stdout;
+    expect(branchLog).toContain("first");
+    expect(branchLog).toContain("cleaned up leftover");
+
+    expect(closeCalls1).toEqual([1]);
+    expect(closeCalls2).toEqual([1]);
+  });
+
+  test("branch (named): rejects when the branch is already checked out elsewhere", async () => {
+    // Put the host repo on the named branch — that's a "checked out
+    // elsewhere" case from our perspective: our strategy expects a worktree
+    // under .sanddune/worktrees/, not the host main worktree.
+    runSync("git", ["checkout", "-b", "agent/conflict"], repo);
+
+    const closeCalls: number[] = [];
+    const provider = makeLocalProcessBindMountProvider(closeCalls);
+    const agent = createAgentProvider({
+      name: "stub",
+      buildCommand: () => "true",
+      parseLine: () => [],
+    });
+
+    const handleRef: { current: BindMountSandboxHandle | undefined } = {
+      current: undefined,
+    };
+    // Worktree setup fails before the agent is invoked, so this should never
+    // be called — fail loudly if the contract slips.
+    const fakeInvoker: AgentInvokerService = {
+      invoke: () => Effect.fail(new Error("invoker should not be called")),
+    };
+
+    await expect(
+      runProgram(
+        {
+          agent,
+          sandbox: capturingProvider(provider, handleRef),
+          prompt: "x",
+          cwd: repo,
+          branchStrategy: { type: "branch", branch: "agent/conflict" },
+        },
+        {
+          agentInvokerLayer: Layer.succeed(AgentInvoker, fakeInvoker),
+        },
+      ),
+    ).rejects.toThrow(/already checked out at/);
+
+    // Lock was released even though setup threw.
+    expect(
+      runSync("ls", [join(repo, ".sanddune", "locks")], repo).stdout.trim(),
+    ).toBe("");
+
+    // Sandbox was never created.
+    expect(closeCalls).toEqual([]);
+  });
+
   test("env merging rejects overlapping agent and sandbox keys", async () => {
     const provider = createBindMountSandboxProvider({
       name: "test",
@@ -359,6 +621,41 @@ function capturingProvider(
       return handle;
     },
   });
+}
+
+function scriptedAgent(
+  handleRef: { current: BindMountSandboxHandle | undefined },
+  scripts: readonly string[],
+): { invoker: AgentInvokerService } {
+  return {
+    invoker: {
+      invoke: ({ iteration }) =>
+        Effect.tryPromise({
+          try: async () => {
+            const handle = handleRef.current;
+            if (!handle) throw new Error("handle not yet captured");
+            const script = scripts[iteration - 1];
+            if (script === undefined) {
+              throw new Error(
+                `no scripted command for iteration ${iteration}`,
+              );
+            }
+            await handle.exec(script);
+            return {
+              events: [
+                {
+                  type: "text" as const,
+                  content: `iteration ${iteration} done\n`,
+                  iteration,
+                  timestamp: Date.now(),
+                },
+              ],
+            };
+          },
+          catch: (e) => (e instanceof Error ? e : new Error(String(e))),
+        }),
+    },
+  };
 }
 
 function runSync(


### PR DESCRIPTION
Closes #6.

## Summary

- Replace the "not yet supported" throw for `branchStrategy: { type: "branch", branch: "<name>" }` with end-to-end wiring through `run()`.
- New `createBranchWorktree` in `worktree-manager.ts` mirrors the merge-to-head lifecycle: lock → create-or-reuse worktree → dirty-preserving close.
- Fix `beforeSha` capture to read off the worktree path, not host cwd. No-op for `head`/`merge-to-head`; correctness fix for `branch` against an existing branch (otherwise `gitNewCommits` would have surfaced pre-existing commits).

## Behavior

| Case | What happens |
| --- | --- |
| New branch | Created from host HEAD via `git worktree add -b` |
| Existing branch, no worktree | Attached via `git worktree add`; commits append |
| Existing branch, worktree on disk | Reused per ADR-0003 (clean → log, dirty → stderr warning) |
| Branch already checked out elsewhere | Fail fast with a clear error |

`close()` follows merge-to-head dirty-preservation policy (ADR-0003) — clean removes, dirty preserves and surfaces via `RunResult.worktreePath`. The named branch itself is never deleted.

Branch names with `/` (the common `agent/foo` pattern) are sanitized by replacing `/` with `-` for the on-disk path. Branches that differ only by `/` vs `-` collide on the same id and lock; the collision surfaces as a fail-fast (lock-held or worktree-already-checked-out), never silent state sharing.

## Acceptance criteria from #6

- [x] `run({ branchStrategy: { type: "branch", branch: "agent/foo" } })` end-to-end
- [x] Existing branch reuse: commits append to tip
- [x] New branch creation from current HEAD
- [x] Branch strategy resolver table-driven tests cover named-branch across (bind-mount, isolated, no-sandbox) — already in `packages/core/src/resolve-branch-strategy.test.ts`
- [x] `RunResult.branch` reports the named branch
- [x] `bun test` and `bun run typecheck` pass

Out of scope (per the linked plan): `createWorktree()` / `wt.*` public entry points, `interactive()` honoring non-default strategies, isolated-provider runtime, user-facing `pruneStale()`.

## Test plan

- [x] `bun run typecheck` (full workspace)
- [x] `bun test packages/sanddune/src/run.integration.test.ts` — 9/9 pass
- New tests cover: new-branch creation, existing-branch append, dirty preservation across two runs, and the "branch already checked out elsewhere" fail-fast (with lock cleanup assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)