### PR TITLE
feat: lifecycle hooks + copyToWorktree wired into run() (#13)

### DIFF
--- a/.changeset/lifecycle-hooks-and-copy-to-worktree.md
+++ b/.changeset/lifecycle-hooks-and-copy-to-worktree.md
@@ -11,7 +11,7 @@ Per ADR-0001 (amended), user-supplied lifecycle steps accept caller-supplied tim
 - Per-hook `timeoutMs?` on host and sandbox hooks (default `60_000ms`).
 - `timeouts.copyToWorktreeMs?` for the `copyToWorktree` step (default `60_000ms`).
 
-Non-zero hook exit fails the run immediately with the offending command and exit code. The caller `signal` is threaded into every hook and the `copyToWorktree` step.
+Non-zero hook exit fails the run immediately with the offending command and exit code. The caller `signal` is threaded into every hook and the `copyToWorktree` step. In the parallel `onSandboxReady` step, a failure on either side cancels the in-flight sibling so a failed run doesn't leave orphan host or sandbox work running.
 
 Breaking type changes (no runtime breakage — these surfaces were not yet wired):
 
@@ -19,4 +19,4 @@ Breaking type changes (no runtime breakage — these surfaces were not yet wired
 - Removed exports: `HostHook`, `SandboxHook`, `HostHooks`, `InSandboxHooks`. The element shape is inlined inside `SandboxHooks`.
 - `RunOptions.copyToWorktree` is now `readonly string[]` — the speculative `{ source, destination? }` object form has been removed along with the `CopyToWorktree` type export.
 
-New typed errors: `HookTimeoutError`, `CopyToWorktreeTimeoutError`.
+New typed errors: `HookTimeoutError`, `CopyToWorktreeTimeoutError` (the latter carries `currentItem` — the resolved path of the entry being copied when the timeout fired).

--- a/.changeset/lifecycle-hooks-and-copy-to-worktree.md
+++ b/.changeset/lifecycle-hooks-and-copy-to-worktree.md
@@ -1,0 +1,22 @@
+---
+"@missingstudio/sanddune": patch
+---
+
+Wire lifecycle hooks and `copyToWorktree` into `run()`.
+
+`copyToWorktree` now copies host paths into the worktree before any hook fires (relative paths resolve against `cwd`; rejected with `branchStrategy: { type: "head" }`). Hooks run as `host.onWorktreeReady` (sequential) → sandbox created → `host.onSandboxReady ∥ sandbox.onSandboxReady` (parallel).
+
+Per ADR-0001 (amended), user-supplied lifecycle steps accept caller-supplied timeout overrides:
+
+- Per-hook `timeoutMs?` on host and sandbox hooks (default `60_000ms`).
+- `timeouts.copyToWorktreeMs?` for the `copyToWorktree` step (default `60_000ms`).
+
+Non-zero hook exit fails the run immediately with the offending command and exit code. The caller `signal` is threaded into every hook and the `copyToWorktree` step.
+
+Breaking type changes (no runtime breakage — these surfaces were not yet wired):
+
+- `SandboxHooks` is now array-only — single-hook shorthand (`HostHook | readonly HostHook[]`) is removed. Wrap a single hook in `[ ... ]`.
+- Removed exports: `HostHook`, `SandboxHook`, `HostHooks`, `InSandboxHooks`. The element shape is inlined inside `SandboxHooks`.
+- `RunOptions.copyToWorktree` is now `readonly string[]` — the speculative `{ source, destination? }` object form has been removed along with the `CopyToWorktree` type export.
+
+New typed errors: `HookTimeoutError`, `CopyToWorktreeTimeoutError`.

--- a/README.md
+++ b/README.md
@@ -159,9 +159,34 @@ const result = await run({
 
 Exactly one of `prompt` / `promptFile` is required. On the template path, sanddune performs host-side `{{KEY}}` substitution before the agent runs: every `{{KEY}}` placeholder is replaced with its value from `promptArgs`, plus the built-in arguments `{{SOURCE_BRANCH}}` and `{{TARGET_BRANCH}}` (resolved from the active branch strategy). Passing `SOURCE_BRANCH` or `TARGET_BRANCH` in `promptArgs` throws — built-ins cannot be overridden. A `{{KEY}}` with no matching arg throws naming the key; unused `promptArgs` keys log a warning. Inline `prompt` skips substitution entirely (per ADR-0008), and combining `prompt` with `promptArgs` throws. Templates can also embed `` !`command` `` shell expressions, evaluated in parallel inside the sandbox before each iteration; substitution runs first, so `{{KEY}}` placeholders inside shell expressions are valid (e.g. `` !`gh issue view {{ISSUE}}` ``). All of this is owned by the `preparePromptPipeline()` module, exported from `@missingstudio/sanddune` for callers who want to reuse the host-side validation outside `run()`.
 
+#### Lifecycle hooks and `copyToWorktree`
+
+`copyToWorktree` accepts a list of host paths (relative paths resolve against `cwd`, the target-repo perspective; absolute paths are used as-is) that are copied into the worktree before any hook fires. Rejected at runtime with `branchStrategy: { type: "head" }` — there is no separate worktree to copy into.
+
+`hooks` runs in this order: `host.onWorktreeReady` (sequential) → sandbox created → `host.onSandboxReady ∥ sandbox.onSandboxReady` (parallel; the two sides are not coordinated, so setup that needs ordering across host/sandbox must live entirely on one side). Host hooks are `{ command, timeoutMs? }`; sandbox hooks add `{ sudo? }`. Per-hook timeout defaults to `60_000ms` and is caller-overridable via `timeoutMs`. The `copyToWorktree` step has its own timeout (`timeouts.copyToWorktreeMs`, default `60_000ms`). Non-zero exit fails the run with the offending command and exit code; the caller `signal` is threaded into every hook so abort kills in-flight commands.
+
+```typescript
+await run({
+  agent: claudeCode("claude-opus-4-7"),
+  sandbox: docker(),
+  branchStrategy: { type: "merge-to-head" },
+  prompt: "...",
+  copyToWorktree: [".env.example", "fixtures/"],
+  hooks: {
+    host: {
+      onWorktreeReady: [{ command: "cp .env.example .env" }],
+    },
+    sandbox: {
+      onSandboxReady: [{ command: "bun install", timeoutMs: 120_000 }],
+    },
+  },
+  timeouts: { copyToWorktreeMs: 30_000 },
+});
+```
+
 #### Accepted by the type but not yet wired
 
-`hooks`, `timeouts`, `logging`, `resumeSession`, `copyToWorktree`. Silently ignored. Don't depend on them.
+`timeouts.idleSeconds`, `timeouts.totalSeconds`, `logging`, `resumeSession`. Silently ignored. Don't depend on them.
 
 ### `RunResult`
 

--- a/docs/adr/0001-per-step-timeouts.md
+++ b/docs/adr/0001-per-step-timeouts.md
@@ -6,10 +6,11 @@ Only agent idle has a timeout today. Every other lifecycle step (container start
 
 ## Decision
 
-Wrap every lifecycle step in `Effect.timeoutFail` via a `withTimeout` utility used at call sites with `.pipe`. Each step gets its own `Data.TaggedError` with `message`, `timeoutMs`, and step-specific context. Defaults are internal — not user-configurable. Rename `TimeoutError` to `AgentIdleTimeoutError`.
+Wrap every lifecycle step in `Effect.timeoutFail` via a `withTimeout` utility used at call sites with `.pipe`. Each step gets its own `Data.TaggedError` with `message`, `timeoutMs`, and step-specific context. Defaults are internal for sanddune-owned steps (container start, git operations, image pulls). User-supplied lifecycle steps — **host hooks**, **sandbox hooks**, and `copyToWorktree` — accept caller-supplied overrides, since their duration is a property of the user's command, not sanddune's plumbing. Rename `TimeoutError` to `AgentIdleTimeoutError`.
 
 ## Consequences
 
 - Bounded execution time on every step
 - 10 timeout error types in `SandboxError`
 - Breaking rename: `TimeoutError` → `AgentIdleTimeoutError`
+- Public surface: per-hook `timeoutMs?` on host/sandbox hooks, and `timeouts.copyToWorktreeMs` on `RunOptions` (default 60_000ms each)

--- a/packages/sanddune/src/core/errors.ts
+++ b/packages/sanddune/src/core/errors.ts
@@ -26,3 +26,29 @@ export class AgentIdleTimeoutError extends Error {
     this.iteration = params.iteration;
   }
 }
+
+export class HookTimeoutError extends Error {
+  readonly _tag = "HookTimeoutError" as const;
+  readonly command: string;
+  readonly timeoutMs: number;
+
+  constructor(params: { command: string; timeoutMs: number }) {
+    super(
+      `Hook timed out after ${params.timeoutMs}ms: ${params.command}`,
+    );
+    this.name = "HookTimeoutError";
+    this.command = params.command;
+    this.timeoutMs = params.timeoutMs;
+  }
+}
+
+export class CopyToWorktreeTimeoutError extends Error {
+  readonly _tag = "CopyToWorktreeTimeoutError" as const;
+  readonly timeoutMs: number;
+
+  constructor(params: { timeoutMs: number }) {
+    super(`copyToWorktree timed out after ${params.timeoutMs}ms`);
+    this.name = "CopyToWorktreeTimeoutError";
+    this.timeoutMs = params.timeoutMs;
+  }
+}

--- a/packages/sanddune/src/core/errors.ts
+++ b/packages/sanddune/src/core/errors.ts
@@ -45,10 +45,16 @@ export class HookTimeoutError extends Error {
 export class CopyToWorktreeTimeoutError extends Error {
   readonly _tag = "CopyToWorktreeTimeoutError" as const;
   readonly timeoutMs: number;
+  /** Resolved absolute path of the item being copied when the timeout fired
+   *  — lets callers identify which entry stalled without re-running. */
+  readonly currentItem: string;
 
-  constructor(params: { timeoutMs: number }) {
-    super(`copyToWorktree timed out after ${params.timeoutMs}ms`);
+  constructor(params: { timeoutMs: number; currentItem: string }) {
+    super(
+      `copyToWorktree timed out after ${params.timeoutMs}ms while copying ${params.currentItem}`,
+    );
     this.name = "CopyToWorktreeTimeoutError";
     this.timeoutMs = params.timeoutMs;
+    this.currentItem = params.currentItem;
   }
 }

--- a/packages/sanddune/src/core/hooks.ts
+++ b/packages/sanddune/src/core/hooks.ts
@@ -1,22 +1,19 @@
-export interface HostHook {
-  readonly command: string;
-}
-
-export interface SandboxHook {
-  readonly command: string;
-  readonly sudo?: boolean;
-}
-
-export interface HostHooks {
-  readonly onWorktreeReady?: HostHook | readonly HostHook[];
-  readonly onSandboxReady?: HostHook | readonly HostHook[];
-}
-
-export interface InSandboxHooks {
-  readonly onSandboxReady?: SandboxHook | readonly SandboxHook[];
-}
-
-export interface SandboxHooks {
-  readonly host?: HostHooks;
-  readonly sandbox?: InSandboxHooks;
-}
+export type SandboxHooks = {
+  readonly host?: {
+    readonly onWorktreeReady?: ReadonlyArray<{
+      readonly command: string;
+      readonly timeoutMs?: number;
+    }>;
+    readonly onSandboxReady?: ReadonlyArray<{
+      readonly command: string;
+      readonly timeoutMs?: number;
+    }>;
+  };
+  readonly sandbox?: {
+    readonly onSandboxReady?: ReadonlyArray<{
+      readonly command: string;
+      readonly sudo?: boolean;
+      readonly timeoutMs?: number;
+    }>;
+  };
+};

--- a/packages/sanddune/src/core/index.ts
+++ b/packages/sanddune/src/core/index.ts
@@ -1,4 +1,9 @@
-export { AgentIdleTimeoutError, NotImplementedError } from "./errors";
+export {
+  AgentIdleTimeoutError,
+  CopyToWorktreeTimeoutError,
+  HookTimeoutError,
+  NotImplementedError,
+} from "./errors";
 export { AgentInvoker } from "./agent-invoker";
 
 export type {
@@ -38,13 +43,7 @@ export type {
   SandboxProvider,
 } from "./sandbox-provider";
 
-export type {
-  HostHook,
-  HostHooks,
-  InSandboxHooks,
-  SandboxHook,
-  SandboxHooks,
-} from "./hooks";
+export type { SandboxHooks } from "./hooks";
 
 export type { Timeouts } from "./timeouts";
 export type { LoggingOption } from "./logging";
@@ -60,7 +59,6 @@ export type {
 
 export type {
   CompletionSignal,
-  CopyToWorktree,
   IterationResult,
   IterationUsage,
   RunOptions,

--- a/packages/sanddune/src/core/interactive.ts
+++ b/packages/sanddune/src/core/interactive.ts
@@ -3,7 +3,6 @@ import type { SandboxHooks } from "./hooks";
 import type { PromptOption } from "./prompt";
 import type { InteractiveSandboxProvider } from "./sandbox-provider";
 import type { Timeouts } from "./timeouts";
-import type { CopyToWorktree } from "./run";
 
 export type InteractiveOptions<
   S extends InteractiveSandboxProvider = InteractiveSandboxProvider,
@@ -14,5 +13,5 @@ export type InteractiveOptions<
   readonly env?: Readonly<Record<string, string>>;
   readonly hooks?: SandboxHooks;
   readonly timeouts?: Timeouts;
-  readonly copyToWorktree?: readonly (string | CopyToWorktree)[];
+  readonly copyToWorktree?: readonly string[];
 };

--- a/packages/sanddune/src/core/run.ts
+++ b/packages/sanddune/src/core/run.ts
@@ -8,11 +8,6 @@ import type {
 } from "./sandbox-provider";
 import type { Timeouts } from "./timeouts";
 
-export interface CopyToWorktree {
-  readonly source: string;
-  readonly destination?: string;
-}
-
 export type CompletionSignal = string;
 
 export interface IterationUsage {
@@ -60,5 +55,5 @@ export type RunOptions<S extends RunSandboxProvider = RunSandboxProvider> =
     readonly logging?: LoggingOption;
     readonly signal?: AbortSignal;
     readonly resumeSession?: string;
-    readonly copyToWorktree?: readonly (string | CopyToWorktree)[];
+    readonly copyToWorktree?: readonly string[];
   };

--- a/packages/sanddune/src/core/sandbox.ts
+++ b/packages/sanddune/src/core/sandbox.ts
@@ -7,7 +7,7 @@ import type {
   ExecResult,
 } from "./sandbox-provider";
 import type { Timeouts } from "./timeouts";
-import type { CopyToWorktree, RunResult } from "./run";
+import type { RunResult } from "./run";
 
 export interface CreateSandboxOptions<
   S extends CreateSandboxProvider = CreateSandboxProvider,
@@ -20,7 +20,7 @@ export interface CreateSandboxOptions<
   readonly hooks?: SandboxHooks;
   readonly timeouts?: Timeouts;
   readonly logging?: LoggingOption;
-  readonly copyToWorktree?: readonly (string | CopyToWorktree)[];
+  readonly copyToWorktree?: readonly string[];
 }
 
 export type SandboxRunOptions = PromptOption & {

--- a/packages/sanddune/src/core/timeouts.ts
+++ b/packages/sanddune/src/core/timeouts.ts
@@ -1,4 +1,6 @@
 export interface Timeouts {
   readonly idleSeconds?: number;
   readonly totalSeconds?: number;
+  /** user-supplied lifecycle steps are caller-configurable. */
+  readonly copyToWorktreeMs?: number;
 }

--- a/packages/sanddune/src/core/worktree.ts
+++ b/packages/sanddune/src/core/worktree.ts
@@ -9,7 +9,7 @@ import type {
   RunSandboxProvider,
 } from "./sandbox-provider";
 import type { Timeouts } from "./timeouts";
-import type { CopyToWorktree, RunResult } from "./run";
+import type { RunResult } from "./run";
 import type { Sandbox } from "./sandbox";
 
 export interface CreateWorktreeOptions {
@@ -30,7 +30,7 @@ export type WorktreeRunOptions<
   readonly timeouts?: Timeouts;
   readonly logging?: LoggingOption;
   readonly signal?: AbortSignal;
-  readonly copyToWorktree?: readonly (string | CopyToWorktree)[];
+  readonly copyToWorktree?: readonly string[];
 };
 
 export type WorktreeInteractiveOptions<
@@ -41,7 +41,7 @@ export type WorktreeInteractiveOptions<
   readonly env?: Readonly<Record<string, string>>;
   readonly hooks?: SandboxHooks;
   readonly timeouts?: Timeouts;
-  readonly copyToWorktree?: readonly (string | CopyToWorktree)[];
+  readonly copyToWorktree?: readonly string[];
 };
 
 export interface WorktreeCreateSandboxOptions<
@@ -53,7 +53,7 @@ export interface WorktreeCreateSandboxOptions<
   readonly hooks?: SandboxHooks;
   readonly timeouts?: Timeouts;
   readonly logging?: LoggingOption;
-  readonly copyToWorktree?: readonly (string | CopyToWorktree)[];
+  readonly copyToWorktree?: readonly string[];
 }
 
 export interface Worktree {

--- a/packages/sanddune/src/internal/abort-with-timeout.ts
+++ b/packages/sanddune/src/internal/abort-with-timeout.ts
@@ -1,0 +1,39 @@
+/** Composes a caller's `AbortSignal` with a per-step timeout into a single
+ *  signal. Aborts when either fires; the timeout's reason is the typed error
+ *  produced by `timeoutErrorFactory` so callers can distinguish a caller
+ *  abort from a timeout via `signal.reason instanceof <YourTimeoutError>`.
+ *
+ *  The returned `cleanup()` must be called in a `finally` to drop the timer
+ *  and the listener on the caller signal — otherwise long-lived caller
+ *  signals leak listeners across many sequential hooks. */
+export interface ComposedSignal {
+  readonly signal: AbortSignal;
+  cleanup(): void;
+}
+
+export function composeWithTimeout(
+  callerSignal: AbortSignal | undefined,
+  timeoutMs: number,
+  timeoutErrorFactory: () => Error,
+): ComposedSignal {
+  const controller = new AbortController();
+  if (callerSignal?.aborted) {
+    controller.abort(callerSignal.reason);
+    return { signal: controller.signal, cleanup: () => {} };
+  }
+  const onCallerAbort = () => {
+    controller.abort(callerSignal!.reason);
+  };
+  callerSignal?.addEventListener("abort", onCallerAbort, { once: true });
+  const timer = setTimeout(
+    () => controller.abort(timeoutErrorFactory()),
+    timeoutMs,
+  );
+  return {
+    signal: controller.signal,
+    cleanup: () => {
+      clearTimeout(timer);
+      callerSignal?.removeEventListener("abort", onCallerAbort);
+    },
+  };
+}

--- a/packages/sanddune/src/internal/copy-to-worktree.test.ts
+++ b/packages/sanddune/src/internal/copy-to-worktree.test.ts
@@ -132,7 +132,7 @@ describe("runCopyToWorktree", () => {
     ).rejects.toThrow(/copyToWorktree failed/);
   });
 
-  test("timeoutMs fires CopyToWorktreeTimeoutError when cp exceeds budget", async () => {
+  test("timeoutMs fires CopyToWorktreeTimeoutError naming the in-flight item", async () => {
     // Generate a fixture cp can't churn through in ms: many small files
     // beats trying to make cp block on FIFOs (macOS cp -R copies the FIFO
     // node without reading it).
@@ -144,16 +144,23 @@ describe("runCopyToWorktree", () => {
       ),
     );
     const start = Date.now();
-    await expect(
-      runCopyToWorktree({
+    let captured: unknown;
+    try {
+      await runCopyToWorktree({
         items: ["many"],
         cwd,
         worktreePath: worktree,
         branchStrategy: { type: "merge-to-head" },
         timeoutMs: 5,
         signal: undefined,
-      }),
-    ).rejects.toBeInstanceOf(CopyToWorktreeTimeoutError);
+      });
+    } catch (e) {
+      captured = e;
+    }
+    expect(captured).toBeInstanceOf(CopyToWorktreeTimeoutError);
+    expect((captured as CopyToWorktreeTimeoutError).currentItem).toBe(
+      join(cwd, "many"),
+    );
     const elapsed = Date.now() - start;
     expect(elapsed).toBeLessThan(10_000);
   });
@@ -177,9 +184,14 @@ describe("runCopyToWorktree", () => {
 
   test("CopyToWorktreeTimeoutError is the typed error class", async () => {
     // Sanity-check the class shape so the wiring is at least exercised.
-    const err = new CopyToWorktreeTimeoutError({ timeoutMs: 60_000 });
+    const err = new CopyToWorktreeTimeoutError({
+      timeoutMs: 60_000,
+      currentItem: "/abs/path/dir",
+    });
     expect(err).toBeInstanceOf(Error);
     expect(err.name).toBe("CopyToWorktreeTimeoutError");
     expect(err.timeoutMs).toBe(60_000);
+    expect(err.currentItem).toBe("/abs/path/dir");
+    expect(err.message).toMatch(/\/abs\/path\/dir/);
   });
 });

--- a/packages/sanddune/src/internal/copy-to-worktree.test.ts
+++ b/packages/sanddune/src/internal/copy-to-worktree.test.ts
@@ -1,0 +1,185 @@
+import { mkdtemp, readFile, writeFile, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { CopyToWorktreeTimeoutError } from "../core";
+import { runCopyToWorktree } from "./copy-to-worktree";
+
+let cwd: string;
+let worktree: string;
+
+beforeEach(async () => {
+  cwd = await mkdtemp(join(tmpdir(), "sanddune-copy-cwd-"));
+  worktree = await mkdtemp(join(tmpdir(), "sanddune-copy-wt-"));
+});
+
+afterEach(async () => {
+  await Bun.$`rm -rf ${cwd} ${worktree}`.quiet();
+});
+
+describe("runCopyToWorktree", () => {
+  test("undefined items is a no-op", async () => {
+    await runCopyToWorktree({
+      items: undefined,
+      cwd,
+      worktreePath: worktree,
+      branchStrategy: { type: "merge-to-head" },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+  });
+
+  test("empty items is a no-op", async () => {
+    await runCopyToWorktree({
+      items: [],
+      cwd,
+      worktreePath: worktree,
+      branchStrategy: { type: "merge-to-head" },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+  });
+
+  test("relative paths resolve against cwd, not process.cwd()", async () => {
+    await writeFile(join(cwd, ".env.example"), "FOO=bar\n");
+    await runCopyToWorktree({
+      items: [".env.example"],
+      cwd,
+      worktreePath: worktree,
+      branchStrategy: { type: "merge-to-head" },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+    const copied = await readFile(join(worktree, ".env.example"), "utf8");
+    expect(copied).toBe("FOO=bar\n");
+  });
+
+  test("absolute paths are used as-is", async () => {
+    const elsewhere = await mkdtemp(join(tmpdir(), "sanddune-copy-other-"));
+    await writeFile(join(elsewhere, "extra.txt"), "hi\n");
+    await runCopyToWorktree({
+      items: [join(elsewhere, "extra.txt")],
+      cwd,
+      worktreePath: worktree,
+      branchStrategy: { type: "branch", branch: "feat/x" },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+    const copied = await readFile(join(worktree, "extra.txt"), "utf8");
+    expect(copied).toBe("hi\n");
+    await Bun.$`rm -rf ${elsewhere}`.quiet();
+  });
+
+  test("copies directories recursively", async () => {
+    await mkdir(join(cwd, "fixtures", "nested"), { recursive: true });
+    await writeFile(join(cwd, "fixtures", "a.txt"), "a\n");
+    await writeFile(join(cwd, "fixtures", "nested", "b.txt"), "b\n");
+    await runCopyToWorktree({
+      items: ["fixtures"],
+      cwd,
+      worktreePath: worktree,
+      branchStrategy: { type: "merge-to-head" },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+    expect(await readFile(join(worktree, "fixtures", "a.txt"), "utf8")).toBe(
+      "a\n",
+    );
+    expect(
+      await readFile(join(worktree, "fixtures", "nested", "b.txt"), "utf8"),
+    ).toBe("b\n");
+  });
+
+  test("copies multiple items in declared order", async () => {
+    await writeFile(join(cwd, "one.txt"), "1\n");
+    await writeFile(join(cwd, "two.txt"), "2\n");
+    await runCopyToWorktree({
+      items: ["one.txt", "two.txt"],
+      cwd,
+      worktreePath: worktree,
+      branchStrategy: { type: "merge-to-head" },
+      timeoutMs: undefined,
+      signal: undefined,
+    });
+    expect(await readFile(join(worktree, "one.txt"), "utf8")).toBe("1\n");
+    expect(await readFile(join(worktree, "two.txt"), "utf8")).toBe("2\n");
+  });
+
+  test("rejected with branchStrategy 'head'", async () => {
+    await writeFile(join(cwd, "x.txt"), "x\n");
+    await expect(
+      runCopyToWorktree({
+        items: ["x.txt"],
+        cwd,
+        worktreePath: worktree,
+        branchStrategy: { type: "head" },
+        timeoutMs: undefined,
+        signal: undefined,
+      }),
+    ).rejects.toThrow(/copyToWorktree.*head/);
+  });
+
+  test("missing source surfaces cp error with non-zero exit", async () => {
+    await expect(
+      runCopyToWorktree({
+        items: ["does-not-exist.txt"],
+        cwd,
+        worktreePath: worktree,
+        branchStrategy: { type: "merge-to-head" },
+        timeoutMs: undefined,
+        signal: undefined,
+      }),
+    ).rejects.toThrow(/copyToWorktree failed/);
+  });
+
+  test("timeoutMs fires CopyToWorktreeTimeoutError when cp exceeds budget", async () => {
+    // Generate a fixture cp can't churn through in ms: many small files
+    // beats trying to make cp block on FIFOs (macOS cp -R copies the FIFO
+    // node without reading it).
+    const fixture = join(cwd, "many");
+    await mkdir(fixture);
+    await Promise.all(
+      Array.from({ length: 4000 }, (_, i) =>
+        writeFile(join(fixture, `f${i}.txt`), "x".repeat(64)),
+      ),
+    );
+    const start = Date.now();
+    await expect(
+      runCopyToWorktree({
+        items: ["many"],
+        cwd,
+        worktreePath: worktree,
+        branchStrategy: { type: "merge-to-head" },
+        timeoutMs: 5,
+        signal: undefined,
+      }),
+    ).rejects.toBeInstanceOf(CopyToWorktreeTimeoutError);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(10_000);
+  });
+
+  test("composes caller signal — pre-aborted signal rejects without spawning", async () => {
+    await writeFile(join(cwd, "a.txt"), "a\n");
+    const reason = new Error("cancelled");
+    const controller = new AbortController();
+    controller.abort(reason);
+    await expect(
+      runCopyToWorktree({
+        items: ["a.txt"],
+        cwd,
+        worktreePath: worktree,
+        branchStrategy: { type: "merge-to-head" },
+        timeoutMs: undefined,
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(reason);
+  });
+
+  test("CopyToWorktreeTimeoutError is the typed error class", async () => {
+    // Sanity-check the class shape so the wiring is at least exercised.
+    const err = new CopyToWorktreeTimeoutError({ timeoutMs: 60_000 });
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("CopyToWorktreeTimeoutError");
+    expect(err.timeoutMs).toBe(60_000);
+  });
+});

--- a/packages/sanddune/src/internal/copy-to-worktree.ts
+++ b/packages/sanddune/src/internal/copy-to-worktree.ts
@@ -1,0 +1,57 @@
+import { isAbsolute, resolve } from "node:path";
+import type { BranchStrategy } from "../core";
+import { CopyToWorktreeTimeoutError } from "../core";
+import { composeWithTimeout } from "./abort-with-timeout";
+import { spawnHost } from "./host-process";
+
+const DEFAULT_COPY_TIMEOUT_MS = 60_000;
+
+/** Copies caller-supplied paths from the host into the worktree before any
+ *  hook fires. Items are resolved relative to `cwd` (the target-repo
+ *  perspective), not `process.cwd()` — see CONTEXT.md "Path resolution"
+ *  for the rationale.
+ *
+ *  Rejected when `branchStrategy.type === "head"` because the agent works
+ *  directly in the host working directory; there is no separate worktree
+ *  to copy into. */
+export async function runCopyToWorktree(input: {
+  readonly items: readonly string[] | undefined;
+  readonly cwd: string;
+  readonly worktreePath: string;
+  readonly branchStrategy: BranchStrategy;
+  readonly timeoutMs: number | undefined;
+  readonly signal: AbortSignal | undefined;
+}): Promise<void> {
+  const { items } = input;
+  if (!items || items.length === 0) return;
+
+  if (input.branchStrategy.type === "head") {
+    throw new Error(
+      `copyToWorktree is not supported with branchStrategy "head" — there is no separate worktree to copy into.`,
+    );
+  }
+
+  const timeoutMs = input.timeoutMs ?? DEFAULT_COPY_TIMEOUT_MS;
+  const composed = composeWithTimeout(
+    input.signal,
+    timeoutMs,
+    () => new CopyToWorktreeTimeoutError({ timeoutMs }),
+  );
+  try {
+    for (const item of items) {
+      const source = isAbsolute(item) ? item : resolve(input.cwd, item);
+      const result = await spawnHost(
+        "cp",
+        ["-R", source, input.worktreePath],
+        { signal: composed.signal },
+      );
+      if (result.exitCode !== 0) {
+        throw new Error(
+          `copyToWorktree failed (exit ${result.exitCode}): cp -R ${source} ${input.worktreePath}\n${result.stderr}`,
+        );
+      }
+    }
+  } finally {
+    composed.cleanup();
+  }
+}

--- a/packages/sanddune/src/internal/copy-to-worktree.ts
+++ b/packages/sanddune/src/internal/copy-to-worktree.ts
@@ -32,22 +32,25 @@ export async function runCopyToWorktree(input: {
   }
 
   const timeoutMs = input.timeoutMs ?? DEFAULT_COPY_TIMEOUT_MS;
+  // `currentSource` is read by the timeout factory at fire time, so the
+  // error names whichever item was in flight when the budget expired.
+  let currentSource = "";
   const composed = composeWithTimeout(
     input.signal,
     timeoutMs,
-    () => new CopyToWorktreeTimeoutError({ timeoutMs }),
+    () => new CopyToWorktreeTimeoutError({ timeoutMs, currentItem: currentSource }),
   );
   try {
     for (const item of items) {
-      const source = isAbsolute(item) ? item : resolve(input.cwd, item);
+      currentSource = isAbsolute(item) ? item : resolve(input.cwd, item);
       const result = await spawnHost(
         "cp",
-        ["-R", source, input.worktreePath],
+        ["-R", currentSource, input.worktreePath],
         { signal: composed.signal },
       );
       if (result.exitCode !== 0) {
         throw new Error(
-          `copyToWorktree failed (exit ${result.exitCode}): cp -R ${source} ${input.worktreePath}\n${result.stderr}`,
+          `copyToWorktree failed (exit ${result.exitCode}): cp -R ${currentSource} ${input.worktreePath}\n${result.stderr}`,
         );
       }
     }

--- a/packages/sanddune/src/internal/hook-runner.test.ts
+++ b/packages/sanddune/src/internal/hook-runner.test.ts
@@ -47,18 +47,18 @@ describe("runHostHooksSequential", () => {
     expect(log).toBe("a\nb\nc\n");
   });
 
-  test("non-zero exit throws fast with command + exit code", async () => {
-    let secondRan = false;
+  test("non-zero exit throws fast — second hook never runs", async () => {
+    const tmp = `/tmp/sanddune-hookrunner-${Math.random().toString(36).slice(2)}`;
     await expect(
       runHostHooksSequential(
         [
-          { command: "exit 7" },
-          { command: `echo "should-not-run" && false` },
+          { command: `mkdir -p ${tmp} && exit 7` },
+          { command: `touch ${tmp}/second-ran` },
         ],
         undefined,
       ),
     ).rejects.toThrow(/exit 7.*exit 7/s);
-    expect(secondRan).toBe(false);
+    expect(await Bun.file(`${tmp}/second-ran`).exists()).toBe(false);
   });
 
   test("undefined hook list is a no-op", async () => {
@@ -198,6 +198,86 @@ describe("runOnSandboxReadyParallel", () => {
       signal: undefined,
     });
     expect(calls).toHaveLength(0);
+  });
+
+  test("host failure cancels in-flight sandbox hook (no orphan)", async () => {
+    let sandboxAbortReason: unknown;
+    let sandboxResolved = false;
+    const { handle } = makeFakeHandle(
+      (_cmd, options) =>
+        new Promise((resolve, reject) => {
+          options?.signal?.addEventListener("abort", () => {
+            sandboxAbortReason = options.signal!.reason;
+            reject(options.signal!.reason);
+          });
+          setTimeout(() => {
+            sandboxResolved = true;
+            resolve(ok());
+          }, 5000);
+        }),
+    );
+
+    const start = Date.now();
+    await expect(
+      runOnSandboxReadyParallel({
+        hostHooks: [{ command: "exit 9" }],
+        sandboxHooks: [{ command: "slow-setup" }],
+        handle,
+        signal: undefined,
+      }),
+    ).rejects.toThrow(/exit 9/);
+
+    expect(Date.now() - start).toBeLessThan(2000);
+    expect(sandboxResolved).toBe(false);
+    expect(sandboxAbortReason).toBeInstanceOf(Error);
+    expect((sandboxAbortReason as Error).message).toMatch(/exit 9/);
+  });
+
+  test("sandbox failure cancels in-flight host hook (no orphan)", async () => {
+    const { handle } = makeFakeHandle(async () => ({
+      stdout: "",
+      stderr: "",
+      exitCode: 13,
+    }));
+
+    const tmp = `/tmp/sanddune-hookrunner-${Math.random().toString(36).slice(2)}`;
+    const start = Date.now();
+    await expect(
+      runOnSandboxReadyParallel({
+        hostHooks: [
+          { command: `mkdir -p ${tmp} && sleep 5 && touch ${tmp}/done` },
+        ],
+        sandboxHooks: [{ command: "fast-fail" }],
+        handle,
+        signal: undefined,
+      }),
+    ).rejects.toThrow(/exit 13/);
+
+    expect(Date.now() - start).toBeLessThan(2000);
+    expect(await Bun.file(`${tmp}/done`).exists()).toBe(false);
+  });
+
+  test("caller signal aborts both sides and surfaces caller reason", async () => {
+    const { handle } = makeFakeHandle(
+      (_cmd, options) =>
+        new Promise((_resolve, reject) => {
+          options?.signal?.addEventListener("abort", () =>
+            reject(options.signal!.reason),
+          );
+        }),
+    );
+    const reason = new Error("user-cancelled");
+    const controller = new AbortController();
+    setTimeout(() => controller.abort(reason), 50);
+
+    await expect(
+      runOnSandboxReadyParallel({
+        hostHooks: [{ command: "sleep 5" }],
+        sandboxHooks: [{ command: "slow" }],
+        handle,
+        signal: controller.signal,
+      }),
+    ).rejects.toBe(reason);
   });
 });
 

--- a/packages/sanddune/src/internal/hook-runner.test.ts
+++ b/packages/sanddune/src/internal/hook-runner.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, test } from "bun:test";
+import type {
+  BindMountSandboxHandle,
+  ExecOptions,
+  ExecResult,
+} from "../core";
+import { HookTimeoutError } from "../core";
+import {
+  runHostHooksSequential,
+  runOnSandboxReadyParallel,
+} from "./hook-runner";
+
+type ExecCall = {
+  readonly command: string;
+  readonly options: ExecOptions | undefined;
+};
+
+function makeFakeHandle(
+  exec: (cmd: string, options?: ExecOptions) => Promise<ExecResult>,
+): { handle: BindMountSandboxHandle; calls: ExecCall[] } {
+  const calls: ExecCall[] = [];
+  const handle: BindMountSandboxHandle = {
+    worktreePath: "/fake",
+    exec: async (command, options) => {
+      calls.push({ command, options });
+      return exec(command, options);
+    },
+    close: async () => {},
+  };
+  return { handle, calls };
+}
+
+const ok = (): ExecResult => ({ stdout: "", stderr: "", exitCode: 0 });
+
+describe("runHostHooksSequential", () => {
+  test("runs hooks in declared order", async () => {
+    const tmp = `/tmp/sanddune-hookrunner-${Math.random().toString(36).slice(2)}`;
+    await runHostHooksSequential(
+      [
+        { command: `mkdir -p ${tmp} && echo a >> ${tmp}/log` },
+        { command: `echo b >> ${tmp}/log` },
+        { command: `echo c >> ${tmp}/log` },
+      ],
+      undefined,
+    );
+    const log = await Bun.file(`${tmp}/log`).text();
+    expect(log).toBe("a\nb\nc\n");
+  });
+
+  test("non-zero exit throws fast with command + exit code", async () => {
+    let secondRan = false;
+    await expect(
+      runHostHooksSequential(
+        [
+          { command: "exit 7" },
+          { command: `echo "should-not-run" && false` },
+        ],
+        undefined,
+      ),
+    ).rejects.toThrow(/exit 7.*exit 7/s);
+    expect(secondRan).toBe(false);
+  });
+
+  test("undefined hook list is a no-op", async () => {
+    await expect(
+      runHostHooksSequential(undefined, undefined),
+    ).resolves.toBeUndefined();
+  });
+
+  test("empty hook list is a no-op", async () => {
+    await expect(
+      runHostHooksSequential([], undefined),
+    ).resolves.toBeUndefined();
+  });
+
+  test("per-hook timeout throws HookTimeoutError", async () => {
+    const start = Date.now();
+    await expect(
+      runHostHooksSequential(
+        [{ command: "sleep 5", timeoutMs: 50 }],
+        undefined,
+      ),
+    ).rejects.toBeInstanceOf(HookTimeoutError);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  test("caller signal mid-hook kills subprocess and surfaces reason", async () => {
+    const controller = new AbortController();
+    const reason = new Error("user-cancelled");
+    const start = Date.now();
+    setTimeout(() => controller.abort(reason), 50);
+    await expect(
+      runHostHooksSequential(
+        [{ command: "sleep 5" }],
+        controller.signal,
+      ),
+    ).rejects.toBe(reason);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(2000);
+  });
+
+  test("pre-aborted signal rejects without spawning", async () => {
+    const reason = new Error("already-cancelled");
+    const controller = new AbortController();
+    controller.abort(reason);
+    await expect(
+      runHostHooksSequential(
+        [{ command: "echo should-not-run" }],
+        controller.signal,
+      ),
+    ).rejects.toBe(reason);
+  });
+});
+
+describe("runOnSandboxReadyParallel", () => {
+  test("starts host and sandbox sides in parallel", async () => {
+    const events: string[] = [];
+    const { handle } = makeFakeHandle(async (cmd) => {
+      events.push(`sandbox-start:${cmd}`);
+      await sleep(80);
+      events.push(`sandbox-end:${cmd}`);
+      return ok();
+    });
+
+    const tmp = `/tmp/sanddune-hookrunner-${Math.random().toString(36).slice(2)}`;
+    await runOnSandboxReadyParallel({
+      hostHooks: [
+        {
+          command: `mkdir -p ${tmp} && sleep 0.08 && echo host-done > ${tmp}/h`,
+        },
+      ],
+      sandboxHooks: [{ command: "sandbox-1" }],
+      handle,
+      signal: undefined,
+    });
+
+    expect(events[0]).toBe("sandbox-start:sandbox-1");
+    expect(events).toContain("sandbox-end:sandbox-1");
+    const hostFile = await Bun.file(`${tmp}/h`).text();
+    expect(hostFile).toBe("host-done\n");
+  });
+
+  test("forwards sudo flag to handle.exec", async () => {
+    const { handle, calls } = makeFakeHandle(async () => ok());
+    await runOnSandboxReadyParallel({
+      hostHooks: undefined,
+      sandboxHooks: [{ command: "apt-get update", sudo: true }],
+      handle,
+      signal: undefined,
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.options?.sudo).toBe(true);
+  });
+
+  test("non-zero sandbox exit throws fast", async () => {
+    const { handle } = makeFakeHandle(async () => ({
+      stdout: "",
+      stderr: "",
+      exitCode: 42,
+    }));
+    await expect(
+      runOnSandboxReadyParallel({
+        hostHooks: undefined,
+        sandboxHooks: [{ command: "doomed" }],
+        handle,
+        signal: undefined,
+      }),
+    ).rejects.toThrow(/exit 42.*doomed/);
+  });
+
+  test("sandbox hook timeout throws HookTimeoutError", async () => {
+    const { handle } = makeFakeHandle(
+      async (_cmd, options) =>
+        new Promise((resolve, reject) => {
+          options?.signal?.addEventListener("abort", () =>
+            reject(options.signal!.reason),
+          );
+          setTimeout(() => resolve(ok()), 5000);
+        }),
+    );
+    await expect(
+      runOnSandboxReadyParallel({
+        hostHooks: undefined,
+        sandboxHooks: [{ command: "slow", timeoutMs: 50 }],
+        handle,
+        signal: undefined,
+      }),
+    ).rejects.toBeInstanceOf(HookTimeoutError);
+  });
+
+  test("undefined hooks on both sides is a no-op", async () => {
+    const { handle, calls } = makeFakeHandle(async () => ok());
+    await runOnSandboxReadyParallel({
+      hostHooks: undefined,
+      sandboxHooks: undefined,
+      handle,
+      signal: undefined,
+    });
+    expect(calls).toHaveLength(0);
+  });
+});
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/sanddune/src/internal/hook-runner.ts
+++ b/packages/sanddune/src/internal/hook-runner.ts
@@ -1,0 +1,97 @@
+import type { BindMountSandboxHandle, SandboxHooks } from "../core";
+import { HookTimeoutError } from "../core";
+import { composeWithTimeout } from "./abort-with-timeout";
+import { spawnHost } from "./host-process";
+
+const DEFAULT_HOOK_TIMEOUT_MS = 60_000;
+
+type HostHook = NonNullable<
+  NonNullable<SandboxHooks["host"]>["onWorktreeReady"]
+>[number];
+
+type SandboxHook = NonNullable<
+  NonNullable<SandboxHooks["sandbox"]>["onSandboxReady"]
+>[number];
+
+/** Runs `host.onWorktreeReady` (or any host-hook list) in declared order.
+ *  Stops at the first non-zero exit or timeout. */
+export async function runHostHooksSequential(
+  hooks: ReadonlyArray<HostHook> | undefined,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  if (!hooks) return;
+  for (const hook of hooks) await runHostHook(hook, signal);
+}
+
+/** Kicks off `host.onSandboxReady` and `sandbox.onSandboxReady` in parallel.
+ *  Within each side the hooks still run sequentially. Per CONTEXT.md the two
+ *  sides are not coordinated — setup that needs ordering across host/sandbox
+ *  must live entirely on one side. */
+export async function runOnSandboxReadyParallel(input: {
+  readonly hostHooks: ReadonlyArray<HostHook> | undefined;
+  readonly sandboxHooks: ReadonlyArray<SandboxHook> | undefined;
+  readonly handle: BindMountSandboxHandle;
+  readonly signal: AbortSignal | undefined;
+}): Promise<void> {
+  const hostSide = runHostHooksSequential(input.hostHooks, input.signal);
+  const sandboxSide = input.sandboxHooks
+    ? runSandboxHooksSequential(input.sandboxHooks, input.handle, input.signal)
+    : Promise.resolve();
+  await Promise.all([hostSide, sandboxSide]);
+}
+
+async function runSandboxHooksSequential(
+  hooks: ReadonlyArray<SandboxHook>,
+  handle: BindMountSandboxHandle,
+  signal: AbortSignal | undefined,
+): Promise<void> {
+  for (const hook of hooks) await runSandboxHook(hook, handle, signal);
+}
+
+async function runHostHook(
+  hook: HostHook,
+  callerSignal: AbortSignal | undefined,
+): Promise<void> {
+  const timeoutMs = hook.timeoutMs ?? DEFAULT_HOOK_TIMEOUT_MS;
+  const composed = composeWithTimeout(callerSignal, timeoutMs, () =>
+    new HookTimeoutError({ command: hook.command, timeoutMs }),
+  );
+  try {
+    const result = await spawnHost("/bin/sh", ["-c", hook.command], {
+      signal: composed.signal,
+    });
+
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `hook failed (exit ${result.exitCode}): ${hook.command}`,
+      );
+    }
+  } finally {
+    composed.cleanup();
+  }
+}
+
+async function runSandboxHook(
+  hook: SandboxHook,
+  handle: BindMountSandboxHandle,
+  callerSignal: AbortSignal | undefined,
+): Promise<void> {
+  const timeoutMs = hook.timeoutMs ?? DEFAULT_HOOK_TIMEOUT_MS;
+  const composed = composeWithTimeout(callerSignal, timeoutMs, () =>
+    new HookTimeoutError({ command: hook.command, timeoutMs }),
+  );
+  try {
+    const result = await handle.exec(hook.command, {
+      ...(hook.sudo !== undefined && { sudo: hook.sudo }),
+      signal: composed.signal,
+    });
+
+    if (result.exitCode !== 0) {
+      throw new Error(
+        `hook failed (exit ${result.exitCode}): ${hook.command}`,
+      );
+    }
+  } finally {
+    composed.cleanup();
+  }
+}

--- a/packages/sanddune/src/internal/hook-runner.ts
+++ b/packages/sanddune/src/internal/hook-runner.ts
@@ -26,18 +26,51 @@ export async function runHostHooksSequential(
 /** Kicks off `host.onSandboxReady` and `sandbox.onSandboxReady` in parallel.
  *  Within each side the hooks still run sequentially. Per CONTEXT.md the two
  *  sides are not coordinated — setup that needs ordering across host/sandbox
- *  must live entirely on one side. */
+ *  must live entirely on one side.
+ *
+ *  Both sides see a signal that aborts when EITHER the caller aborts OR the
+ *  sibling side rejects. Without that, a fast-failing side would leave the
+ *  other running — orphan sandbox work after `run()` has thrown, and an
+ *  unhandled rejection if the loser later throws too. */
 export async function runOnSandboxReadyParallel(input: {
   readonly hostHooks: ReadonlyArray<HostHook> | undefined;
   readonly sandboxHooks: ReadonlyArray<SandboxHook> | undefined;
   readonly handle: BindMountSandboxHandle;
   readonly signal: AbortSignal | undefined;
 }): Promise<void> {
-  const hostSide = runHostHooksSequential(input.hostHooks, input.signal);
+  const ac = new AbortController();
+  const callerSignal = input.signal;
+  const onCallerAbort = () => ac.abort(callerSignal!.reason);
+  if (callerSignal) {
+    if (callerSignal.aborted) ac.abort(callerSignal.reason);
+    else callerSignal.addEventListener("abort", onCallerAbort, { once: true });
+  }
+
+  let firstError: { value: unknown } | undefined;
+  const recordAndCancel = (e: unknown): never => {
+    if (!firstError) firstError = { value: e };
+    if (!ac.signal.aborted) ac.abort(e);
+    throw e;
+  };
+
+  const hostSide = runHostHooksSequential(input.hostHooks, ac.signal).catch(
+    recordAndCancel,
+  );
   const sandboxSide = input.sandboxHooks
-    ? runSandboxHooksSequential(input.sandboxHooks, input.handle, input.signal)
+    ? runSandboxHooksSequential(
+        input.sandboxHooks,
+        input.handle,
+        ac.signal,
+      ).catch(recordAndCancel)
     : Promise.resolve();
-  await Promise.all([hostSide, sandboxSide]);
+
+  try {
+    await Promise.allSettled([hostSide, sandboxSide]);
+    if (firstError) throw firstError.value;
+  } finally {
+    if (callerSignal)
+      callerSignal.removeEventListener("abort", onCallerAbort);
+  }
 }
 
 async function runSandboxHooksSequential(

--- a/packages/sanddune/src/internal/run-program.ts
+++ b/packages/sanddune/src/internal/run-program.ts
@@ -11,6 +11,11 @@ import {
 import { resolveEnv } from "./env-resolver";
 import { gitCurrentBranch, gitHeadSha } from "./git";
 import { makeProductionAgentInvoker } from "./agent-invoker-live";
+import { runCopyToWorktree } from "./copy-to-worktree";
+import {
+  runHostHooksSequential,
+  runOnSandboxReadyParallel,
+} from "./hook-runner";
 import { runIterationLoop } from "./iteration-loop";
 import { runEffect } from "./run-effect";
 import { openRunSession, type RunSession } from "./run-session";
@@ -48,9 +53,10 @@ export async function runProgram(
     runOptionsEnv: options.env,
   });
   const targetBranch = await gitCurrentBranch(cwd);
+  const branchStrategy = options.branchStrategy ?? { type: "head" };
 
   const strategy = await createWorktreeStrategy({
-    strategy: options.branchStrategy ?? { type: "head" },
+    strategy: branchStrategy,
     providerKind: provider.kind,
     cwd,
     hostBranch: targetBranch,
@@ -85,6 +91,23 @@ export async function runProgram(
 
     session = await openRunSession(cwd);
 
+    // Lifecycle (CONTEXT.md): copyToWorktree → host.onWorktreeReady →
+    // sandbox created → host.onSandboxReady ∥ sandbox.onSandboxReady.
+    // All threaded with the caller's signal so abort cancels mid-step.
+    await runCopyToWorktree({
+      items: options.copyToWorktree,
+      cwd,
+      worktreePath: strategy.worktreePath,
+      branchStrategy,
+      timeoutMs: options.timeouts?.copyToWorktreeMs,
+      signal: options.signal,
+    });
+
+    await runHostHooksSequential(
+      options.hooks?.host?.onWorktreeReady,
+      options.signal,
+    );
+
     // Anything past this SHA on the worktree's HEAD after the loop is the
     // agent's contribution.
     const beforeSha = await gitHeadSha(strategy.worktreePath);
@@ -93,6 +116,13 @@ export async function runProgram(
       worktreePath: strategy.worktreePath,
       hostRepoPath: cwd,
       env,
+    });
+
+    await runOnSandboxReadyParallel({
+      hostHooks: options.hooks?.host?.onSandboxReady,
+      sandboxHooks: options.hooks?.sandbox?.onSandboxReady,
+      handle,
+      signal: options.signal,
     });
 
     const agentInvokerLayer =


### PR DESCRIPTION
## Summary

Implements [#13](https://github.com/missingstudio/sanddune/issues/13): the `HookRunner` module + `copyToWorktree` step, wired into `run()`. Closes #13.

- **HookRunner**: sequential `host.onWorktreeReady` → parallel `host.onSandboxReady ∥ sandbox.onSandboxReady`, per-hook `timeoutMs` (default 60_000), caller `signal` threaded so abort SIGTERMs in-flight commands, non-zero exit fails the run with the offending command + exit code.
- **copyToWorktree**: relative paths resolve against `cwd` (target-repo perspective), absolute used as-is, rejected at runtime with `branchStrategy: { type: "head" }`, single-step timeout overridable via `timeouts.copyToWorktreeMs` (default 60_000).
- Wired into `run()` only — `interactive()` / `Sandbox` / `Worktree` accept the options at the type level but don't fire yet (slices #16/#17/#18 own those entry points).

### ADR-0001 amended

Per maintainer decision during triage of #13, ADR-0001's "defaults are internal — not user-configurable" clause was amended: user-supplied lifecycle steps (hooks, `copyToWorktree`) now accept caller-supplied overrides; sanddune-internal steps (container start, git ops) remain internal-default. New public surface: per-hook `timeoutMs?` and `timeouts.copyToWorktreeMs`.

### Breaking type changes (no runtime breakage — these surfaces were not yet wired)

- `SandboxHooks` is arrays-only; single-hook shorthand removed. Wrap in `[ ... ]`.
- Removed exports: `HostHook`, `SandboxHook`, `HostHooks`, `InSandboxHooks`. Element shape is inlined inside `SandboxHooks`.
- `RunOptions.copyToWorktree` is `readonly string[]` — object form (`CopyToWorktree`) dropped.

### New typed errors

`HookTimeoutError`, `CopyToWorktreeTimeoutError` — exported from `@missingstudio/sanddune`.

## Test plan

- [x] `bun run typecheck` clean (root turbo run)
- [x] `bun test` — 145 pass / 1 pre-existing skip / 0 fail
- [x] 12 new hook-runner unit tests cover: sequential ordering, parallel start, default timeout fallback, per-hook `timeoutMs` → `HookTimeoutError`, signal mid-hook → SIGTERM, pre-aborted signal short-circuits spawn, non-zero exit throws fast, sandbox `sudo` flag forwarded
- [x] 11 new copy-to-worktree unit tests cover: undefined/empty no-op, relative-vs-`cwd` resolution, absolute paths as-is, recursive directory copy, multi-item ordering, head-strategy rejection, missing source surfaces cp error, custom `timeoutMs` → `CopyToWorktreeTimeoutError` (4000-file fixture), pre-aborted signal short-circuits spawn

## Notes for review

- Shared timeout-composition helper is extracted to `internal/abort-with-timeout.ts` (used by both hook-runner and copy-to-worktree).
- README updated: `hooks` and `copyToWorktree` removed from the "not yet wired" list, new doc section + example added.
- Changeset: `patch`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)