### PR TITLE
feat: Claude Code session capture and resume (#14)

### DIFF
--- a/.changeset/session-capture-and-resume.md
+++ b/.changeset/session-capture-and-resume.md
@@ -1,0 +1,16 @@
+---
+"@missingstudio/sanddune": patch
+---
+
+Add Claude-Code-specific **agent session** capture and resume.
+
+After each iteration with `claudeCode()` (default `captureSessions: true`), the session JSONL is transferred from the **sandbox** to the **host** at `~/.claude/projects/<encoded-path>/sessions/<session-id>.jsonl`, with `cwd` fields rewritten to the host repo root so `claude --resume` works natively. `IterationResult.sessionId` and `IterationResult.sessionFilePath` are populated on success. Capture is **best-effort** — failure logs a warning to stderr and leaves `sessionFilePath` undefined; the run still resolves successfully.
+
+`RunOptions.resumeSession: "<id>"` validates the host file exists, transfers it into the sandbox with `cwd` rewritten to the sandbox-side worktree path, and passes `--resume <id>` to Claude Code on iteration 1 only. Validation runs **before** sandbox creation:
+
+- `resumeSession` + `maxIterations > 1` throws (long-lived loops can't chain Claude session state).
+- Missing host session file throws.
+
+Opt out with `claudeCode("model", { captureSessions: false })`. Non-Claude agent providers ignore `captureSessions` and `resumeSession` (no-ops, no errors).
+
+New optional surface on the `AgentProvider` interface: `sessionCapture?: AgentSessionCapture` (parses session id from a stream line, owns host/sandbox path layout, and rewrites `cwd` fields). `AgentBuildCommandInput` gains `resumeSessionId?: string` so providers can append their own resume args. New `IterationResult.sessionId?: string` field complements the existing `sessionFilePath`.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ A run goes through three phases:
 2. **Agent invocation** — invoke the agent with the (inline) prompt, stream JSON events into the run log, capture stdout text events.
 3. **Teardown** — read commits off the worktree HEAD, fast-forward back to the host branch (`merge-to-head` only), tear down the container, and clean up the worktree (preserving it on disk if dirty).
 
-The iteration loop honors `maxIterations` (default `1`), `completionSignal` (default `<promise>COMPLETE</promise>`, substring-matched against the agent's text events; first match across iterations wins), `idleTimeoutSeconds` (default `600`; resets on every agent stream event — on expiry the agent subprocess is killed and the run rejects with `AgentIdleTimeoutError`), and `signal` (caller-supplied `AbortSignal` — when it fires mid-iteration, the agent subprocess is killed and `run()` rejects with `signal.reason` verbatim; the worktree is left as-is per ADR-0011). For **prompt templates**, **prompt expansion** evaluates `` !`shell expressions` `` once per iteration before the agent is invoked. **Agent session** capture is not yet wired.
+The iteration loop honors `maxIterations` (default `1`), `completionSignal` (default `<promise>COMPLETE</promise>`, substring-matched against the agent's text events; first match across iterations wins), `idleTimeoutSeconds` (default `600`; resets on every agent stream event — on expiry the agent subprocess is killed and the run rejects with `AgentIdleTimeoutError`), and `signal` (caller-supplied `AbortSignal` — when it fires mid-iteration, the agent subprocess is killed and `run()` rejects with `signal.reason` verbatim; the worktree is left as-is per ADR-0011). For **prompt templates**, **prompt expansion** evaluates `` !`shell expressions` `` once per iteration before the agent is invoked. With `claudeCode()` (default `captureSessions: true`), each iteration's session JSONL is captured from the sandbox to `~/.claude/projects/<encoded-cwd>/sessions/<id>.jsonl` on the host with `cwd` fields rewritten so `claude --resume` works natively; capture is best-effort (failure logs a warning and the run still resolves successfully).
 
 ## Branch strategies
 
@@ -184,9 +184,11 @@ await run({
 });
 ```
 
+`resumeSession: "<id>"` continues a prior Claude Code session in a fresh sandbox. Validated **before** sandbox creation: the host session file must exist (at the path written by a previous capture), and the option is rejected when combined with `maxIterations > 1`. The file is transferred into the sandbox with `cwd` rewritten, and `--resume <id>` is passed to Claude Code on iteration 1 only — subsequent iterations start fresh. Non-Claude agent providers ignore `resumeSession`.
+
 #### Accepted by the type but not yet wired
 
-`timeouts.idleSeconds`, `timeouts.totalSeconds`, `logging`, `resumeSession`. Silently ignored. Don't depend on them.
+`timeouts.idleSeconds`, `timeouts.totalSeconds`, `logging`. Silently ignored. Don't depend on them.
 
 ### `RunResult`
 
@@ -204,7 +206,8 @@ interface RunResult {
 interface IterationResult {
   iteration: number;
   commitSha?: string;              // last commit produced on this iteration, if any
-  sessionFilePath?: string;        // not set today (capture not implemented)
+  sessionId?: string;              // agent session id (Claude Code system/init), when sessionCapture is configured
+  sessionFilePath?: string;        // host path to captured JSONL, when capture succeeded
   usage?: IterationUsage;          // not set today
   completionSignal?: string;       // set on the iteration that matched the completion signal
 }
@@ -258,10 +261,11 @@ The container is started with `-w /workspace` and the worktree bind-mounted ther
 ```typescript
 claudeCode("claude-opus-4-7", {
   env: { ANTHROPIC_API_KEY: "sk-ant-..." },   // optional; merged per ADR-0012
+  captureSessions: true,                       // optional; default true. Set false to skip session capture
 })
 ```
 
-Today's `ClaudeCodeOptions` is `{ env? }`. The `effort` and `captureSessions` options shown in the brief don't exist yet.
+`captureSessions` controls whether each iteration's **agent session** JSONL is captured from the sandbox to the host (`~/.claude/projects/<encoded-cwd>/sessions/<id>.jsonl`, with `cwd` rewritten so `claude --resume` works natively). Capture is best-effort — failure logs a warning and the run still resolves successfully. The `effort` option shown in the brief doesn't exist yet.
 
 ### Custom bind-mount providers
 

--- a/packages/sanddune/src/agents/claude-code.test.ts
+++ b/packages/sanddune/src/agents/claude-code.test.ts
@@ -1,0 +1,169 @@
+import { homedir } from "node:os";
+import { describe, expect, test } from "bun:test";
+import { claudeCode } from "./claude-code";
+
+describe("claudeCode buildCommand", () => {
+  test("emits --dangerously-skip-permissions and the prompt; no --resume by default", () => {
+    const provider = claudeCode("claude-opus-4-7");
+    const cmd = provider.buildCommand({ prompt: "do the thing", iteration: 1 });
+    expect(cmd).toContain("'do the thing'");
+    expect(cmd).toContain("--dangerously-skip-permissions");
+    expect(cmd).not.toContain("--resume");
+  });
+
+  test("appends --resume <id> when resumeSessionId is set", () => {
+    const provider = claudeCode("claude-opus-4-7");
+    const cmd = provider.buildCommand({
+      prompt: "continue",
+      iteration: 1,
+      resumeSessionId: "abc-123",
+    });
+    expect(cmd).toContain("--resume 'abc-123'");
+    // resume must come before the prompt arg, after the model + skip-perms,
+    // so the trailing positional prompt remains the last token group.
+    const resumeIdx = cmd.indexOf("--resume");
+    const promptIdx = cmd.lastIndexOf("'continue'");
+    expect(resumeIdx).toBeGreaterThan(0);
+    expect(promptIdx).toBeGreaterThan(resumeIdx);
+  });
+
+  test("shell-quotes session id (defensive — Claude session ids are uuid-like)", () => {
+    const provider = claudeCode("m");
+    const cmd = provider.buildCommand({
+      prompt: "p",
+      iteration: 1,
+      resumeSessionId: "weird'id",
+    });
+    expect(cmd).toContain(`--resume 'weird'\\''id'`);
+  });
+});
+
+describe("claudeCode sessionCapture capability", () => {
+  test("present by default", () => {
+    expect(claudeCode("m").sessionCapture).toBeDefined();
+  });
+
+  test("absent when captureSessions: false (opt-out)", () => {
+    expect(claudeCode("m", { captureSessions: false }).sessionCapture).toBeUndefined();
+  });
+
+  test("present when captureSessions: true (explicit)", () => {
+    expect(claudeCode("m", { captureSessions: true }).sessionCapture).toBeDefined();
+  });
+});
+
+describe("claudeCode sessionCapture.parseSessionId", () => {
+  const capture = claudeCode("m").sessionCapture!;
+
+  test("extracts session_id from a system/init line", () => {
+    const line = JSON.stringify({
+      type: "system",
+      subtype: "init",
+      session_id: "abc-123-def",
+      cwd: "/workspace",
+    });
+    expect(capture.parseSessionId(line)).toBe("abc-123-def");
+  });
+
+  test("returns undefined for non-init system lines", () => {
+    const line = JSON.stringify({
+      type: "system",
+      subtype: "tool_result",
+      session_id: "should-be-ignored",
+    });
+    expect(capture.parseSessionId(line)).toBeUndefined();
+  });
+
+  test("returns undefined for assistant lines (the streaming text)", () => {
+    const line = JSON.stringify({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "hi" }] },
+    });
+    expect(capture.parseSessionId(line)).toBeUndefined();
+  });
+
+  test("returns undefined for malformed JSON / blank lines", () => {
+    expect(capture.parseSessionId("")).toBeUndefined();
+    expect(capture.parseSessionId("not json")).toBeUndefined();
+    expect(capture.parseSessionId("{")).toBeUndefined();
+  });
+
+  test("returns undefined when session_id is missing or empty", () => {
+    expect(
+      capture.parseSessionId(
+        JSON.stringify({ type: "system", subtype: "init" }),
+      ),
+    ).toBeUndefined();
+    expect(
+      capture.parseSessionId(
+        JSON.stringify({ type: "system", subtype: "init", session_id: "" }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+describe("claudeCode sessionCapture path encoding", () => {
+  const capture = claudeCode("m").sessionCapture!;
+
+  test("hostSessionPath uses HOME, encoded cwd, and the sessions/ subdir", () => {
+    const p = capture.hostSessionPath("/Users/me/repo", "abc-123");
+    expect(p).toBe(
+      `${homedir()}/.claude/projects/-Users-me-repo/sessions/abc-123.jsonl`,
+    );
+  });
+
+  test("sandboxSessionPath uses ~ + encoded cwd, no sessions/ subdir", () => {
+    const p = capture.sandboxSessionPath("/workspace", "abc-123");
+    expect(p).toBe("~/.claude/projects/-workspace/abc-123.jsonl");
+  });
+});
+
+describe("claudeCode sessionCapture.rewriteCwd", () => {
+  const capture = claudeCode("m").sessionCapture!;
+
+  test("rewrites cwd in every matching record (sandbox → host)", () => {
+    const sandbox = "/workspace";
+    const host = "/Users/me/repo";
+    const jsonl =
+      JSON.stringify({ type: "user", cwd: sandbox, message: "a" }) +
+      "\n" +
+      JSON.stringify({ type: "assistant", cwd: sandbox, message: "b" }) +
+      "\n";
+    const out = capture.rewriteCwd(jsonl, sandbox, host);
+    const lines = out.split("\n").filter((l) => l.length > 0);
+    expect(lines).toHaveLength(2);
+    for (const line of lines) {
+      expect(JSON.parse(line).cwd).toBe(host);
+    }
+  });
+
+  test("rewrites in the reverse direction too (host → sandbox), used by resume transfer", () => {
+    const sandbox = "/workspace";
+    const host = "/Users/me/repo";
+    const jsonl =
+      JSON.stringify({ type: "user", cwd: host }) + "\n";
+    const out = capture.rewriteCwd(jsonl, host, sandbox);
+    const line = out.split("\n").find((l) => l.length > 0)!;
+    expect(JSON.parse(line).cwd).toBe(sandbox);
+  });
+
+  test("leaves records with non-matching cwd untouched", () => {
+    const jsonl =
+      JSON.stringify({ type: "user", cwd: "/something/else" }) + "\n";
+    const out = capture.rewriteCwd(jsonl, "/workspace", "/host");
+    const line = out.split("\n").find((l) => l.length > 0)!;
+    expect(JSON.parse(line).cwd).toBe("/something/else");
+  });
+
+  test("preserves trailing newline and skips malformed lines", () => {
+    const sandbox = "/workspace";
+    const host = "/host";
+    const good = JSON.stringify({ type: "user", cwd: sandbox });
+    const jsonl = `${good}\nnot json\n`;
+    const out = capture.rewriteCwd(jsonl, sandbox, host);
+    expect(out.endsWith("\n")).toBe(true);
+    const lines = out.split("\n");
+    expect(JSON.parse(lines[0]!).cwd).toBe(host);
+    expect(lines[1]).toBe("not json");
+  });
+});

--- a/packages/sanddune/src/agents/claude-code.ts
+++ b/packages/sanddune/src/agents/claude-code.ts
@@ -1,17 +1,29 @@
-import type { AgentProvider, AgentStreamEvent } from "../core";
+import { homedir } from "node:os";
+import type {
+  AgentProvider,
+  AgentSessionCapture,
+  AgentStreamEvent,
+} from "../core";
 
 export interface ClaudeCodeOptions {
   readonly env?: Readonly<Record<string, string>>;
+  /** Capture each iteration's **agent session** JSONL from the **sandbox**
+   *  to the **host** (default `true`). Set `false` to opt out — capture
+   *  becomes a no-op and `IterationResult.sessionId` /
+   *  `IterationResult.sessionFilePath` stay `undefined`. */
+  readonly captureSessions?: boolean;
 }
 
 export function claudeCode(
   model: string,
   options?: ClaudeCodeOptions,
 ): AgentProvider {
+  const captureSessions = options?.captureSessions ?? true;
   return {
     name: "claude-code",
     env: options?.env,
-    buildCommand: ({ prompt }) => {
+    ...(captureSessions && { sessionCapture: claudeCodeSessionCapture }),
+    buildCommand: ({ prompt, resumeSessionId }) => {
       const args = [
         "claude",
         "--print",
@@ -21,8 +33,11 @@ export function claudeCode(
         "--model",
         shellQuote(model),
         "--dangerously-skip-permissions",
-        shellQuote(prompt),
       ];
+      if (resumeSessionId !== undefined) {
+        args.push("--resume", shellQuote(resumeSessionId));
+      }
+      args.push(shellQuote(prompt));
       return args.join(" ");
     },
     parseLine: (line, iteration) => parseClaudeCodeLine(line, iteration),
@@ -78,6 +93,59 @@ function parseClaudeCodeLine(
   }
   return events;
 }
+
+/** Claude Code's on-disk path encoding: take the absolute path, replace every
+ *  `/` with `-`. So `/Users/me/repo` becomes `-Users-me-repo`. Matches the
+ *  layout under `~/.claude/projects/` that `claude --resume` reads from. */
+function encodeProjectDir(absPath: string): string {
+  return absPath.replace(/\//g, "-");
+}
+
+const claudeCodeSessionCapture: AgentSessionCapture = {
+  parseSessionId(line) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) return undefined;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch {
+      return undefined;
+    }
+    if (!isRecord(parsed)) return undefined;
+    if (parsed.type !== "system" || parsed["subtype"] !== "init") {
+      return undefined;
+    }
+    const id = parsed["session_id"];
+    return typeof id === "string" && id.length > 0 ? id : undefined;
+  },
+  hostSessionPath(hostCwd, sessionId) {
+    return `${homedir()}/.claude/projects/${encodeProjectDir(
+      hostCwd,
+    )}/sessions/${sessionId}.jsonl`;
+  },
+  sandboxSessionPath(sandboxCwd, sessionId) {
+    return `~/.claude/projects/${encodeProjectDir(sandboxCwd)}/${sessionId}.jsonl`;
+  },
+  rewriteCwd(jsonl, fromCwd, toCwd) {
+    const lines = jsonl.split("\n");
+    return lines
+      .map((line, idx) => {
+        // Preserve a final trailing newline (split produces an empty tail).
+        if (line.length === 0 && idx === lines.length - 1) return line;
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(line);
+        } catch {
+          // Best-effort: leave malformed lines untouched.
+          return line;
+        }
+        if (!isRecord(parsed)) return line;
+        if (parsed["cwd"] !== fromCwd) return line;
+        return JSON.stringify({ ...parsed, cwd: toCwd });
+      })
+      .join("\n");
+  },
+};
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);

--- a/packages/sanddune/src/core/agent-invoker.ts
+++ b/packages/sanddune/src/core/agent-invoker.ts
@@ -16,11 +16,21 @@ export interface AgentInvokeInput {
    *  signal is owned inside the invoker; callers do not see the composite.
    *  A non-positive value disables the watchdog. */
   readonly idleTimeoutSeconds: number;
+  /** When set, forwarded to `agentProvider.buildCommand` so the agent can
+   *  emit its provider-specific resume args (e.g. Claude Code's
+   *  `--resume <id>`). The **iteration loop** sets this only on iteration 1
+   *  when `RunOptions.resumeSession` is configured. */
+  readonly resumeSessionId?: string;
 }
 
 export interface AgentInvokeResult {
   readonly events: readonly AgentStreamEvent[];
   readonly completionSignal?: CompletionSignal;
+  /** Captured iff the **agent provider** has a `sessionCapture` capability
+   *  AND emitted a session id during streaming (Claude Code does this via
+   *  the `system/init` line). The **iteration loop** uses this to drive the
+   *  best-effort capture step. */
+  readonly sessionId?: string;
 }
 
 export interface AgentInvokerService {

--- a/packages/sanddune/src/core/agent-provider.ts
+++ b/packages/sanddune/src/core/agent-provider.ts
@@ -16,11 +16,47 @@ export type AgentStreamEvent =
 export interface AgentBuildCommandInput {
   readonly prompt: string;
   readonly iteration: number;
+  /** When set, the **agent provider** appends provider-specific resume args
+   *  (e.g. Claude Code's `--resume <id>`). Forwarded by the **agent invoker**
+   *  on iteration 1 only when `RunOptions.resumeSession` is set; `undefined`
+   *  on every other turn. Providers without resume support ignore it. */
+  readonly resumeSessionId?: string;
+}
+
+/** Agent-specific glue for **agent session** capture and resume. Optional;
+ *  agents that have no concept of a resumable session simply omit it and
+ *  capture/resume become no-ops at the run-program level.
+ *
+ *  All paths returned are absolute strings that can be passed to
+ *  `BindMountSandboxHandle.exec` (host paths are absolute filesystem paths;
+ *  sandbox paths may begin with `~` since they are evaluated by the sandbox
+ *  shell). `rewriteCwd` operates on the JSONL text — one record per line —
+ *  and is responsible for replacing every entry's `cwd` field from
+ *  `fromCwd` to `toCwd` while leaving the rest of the record intact. */
+export interface AgentSessionCapture {
+  /** Inspect a raw stream line and return the **agent session** id it
+   *  carries, if any. The first non-undefined return wins for an iteration —
+   *  the **agent invoker** stops calling once it has an id. */
+  parseSessionId(line: string): string | undefined;
+  /** Where the captured JSONL is written on the **host**. */
+  hostSessionPath(hostCwd: string, sessionId: string): string;
+  /** Where the **agent** writes the JSONL inside the **sandbox** (the file
+   *  the **iteration loop** reads back to capture, and the file resume
+   *  transfers in to). May begin with `~`. */
+  sandboxSessionPath(sandboxCwd: string, sessionId: string): string;
+  /** Rewrite all `cwd` fields in the JSONL from `fromCwd` to `toCwd`. */
+  rewriteCwd(jsonl: string, fromCwd: string, toCwd: string): string;
 }
 
 export interface AgentProvider {
   readonly name: string;
   readonly env?: Readonly<Record<string, string>>;
+  /** Optional **agent session** capture/resume capability. Present iff the
+   *  agent supports it AND the user has not opted out (e.g.
+   *  `claudeCode({ captureSessions: false })`). Absent → capture and
+   *  `resumeSession` become no-ops; `resumeSession` is silently ignored
+   *  rather than rejected, mirroring the brief / CONTEXT.md. */
+  readonly sessionCapture?: AgentSessionCapture;
   buildCommand(input: AgentBuildCommandInput): string;
   parseLine(line: string, iteration: number): readonly AgentStreamEvent[];
 }

--- a/packages/sanddune/src/core/index.ts
+++ b/packages/sanddune/src/core/index.ts
@@ -23,6 +23,7 @@ export type {
 export type {
   AgentBuildCommandInput,
   AgentProvider,
+  AgentSessionCapture,
   AgentStreamEvent,
 } from "./agent-provider";
 

--- a/packages/sanddune/src/core/run.ts
+++ b/packages/sanddune/src/core/run.ts
@@ -20,6 +20,14 @@ export interface IterationUsage {
 export interface IterationResult {
   readonly iteration: number;
   readonly commitSha?: string;
+  /** **Agent session** id, populated when the agent provider has a
+   *  `sessionCapture` capability and emitted an id during the iteration.
+   *  `undefined` for non-Claude providers and when `captureSessions: false`. */
+  readonly sessionId?: string;
+  /** Absolute host path to the captured **agent session** JSONL. Populated
+   *  only when capture succeeds; capture failure logs a warning and leaves
+   *  this `undefined` (run still resolves successfully — see CONTEXT.md
+   *  "agent session capture is best-effort"). */
   readonly sessionFilePath?: string;
   readonly usage?: IterationUsage;
   readonly completionSignal?: CompletionSignal;

--- a/packages/sanddune/src/internal/agent-invoker-live.test.ts
+++ b/packages/sanddune/src/internal/agent-invoker-live.test.ts
@@ -77,6 +77,7 @@ function runInvoke(
     iteration?: number;
     idleTimeoutSeconds: number;
     signal?: AbortSignal;
+    resumeSessionId?: string;
   },
 ) {
   return runEffect(
@@ -85,6 +86,9 @@ function runInvoke(
       iteration: input.iteration ?? 1,
       idleTimeoutSeconds: input.idleTimeoutSeconds,
       ...(input.signal !== undefined && { signal: input.signal }),
+      ...(input.resumeSessionId !== undefined && {
+        resumeSessionId: input.resumeSessionId,
+      }),
     }),
   );
 }
@@ -233,6 +237,74 @@ describe("makeProductionAgentInvoker — caller signal composition (ADR-0011)", 
       }),
     ).rejects.toBe(reason);
     expect(observed).toEqual([]);
+  });
+});
+
+describe("makeProductionAgentInvoker — session capture", () => {
+  test("forwards resumeSessionId to buildCommand", async () => {
+    const seen: { resumeSessionId: string | undefined }[] = [];
+    const provider: AgentProvider = {
+      name: "fake",
+      buildCommand: ({ resumeSessionId }) => {
+        seen.push({ resumeSessionId });
+        return "x";
+      },
+      parseLine: () => [],
+    };
+    const handle = makeFakeHandle([{ line: "ignored", afterMs: 1 }]);
+    const invoker = makeProductionAgentInvoker({
+      agentProvider: provider,
+      handle,
+      onEvent: () => {},
+    });
+
+    await runInvoke(invoker, { idleTimeoutSeconds: 60 });
+    await runInvoke(invoker, {
+      idleTimeoutSeconds: 60,
+      resumeSessionId: "session-XYZ",
+    });
+
+    expect(seen[0]?.resumeSessionId).toBeUndefined();
+    expect(seen[1]?.resumeSessionId).toBe("session-XYZ");
+  });
+
+  test("extracts sessionId from the first matching line; result.sessionId is set", async () => {
+    const provider: AgentProvider = {
+      name: "fake",
+      sessionCapture: {
+        parseSessionId: (line) =>
+          line.startsWith("INIT:") ? line.slice(5) : undefined,
+        hostSessionPath: () => "/host/x.jsonl",
+        sandboxSessionPath: () => "/sb/x.jsonl",
+        rewriteCwd: (s) => s,
+      },
+      buildCommand: () => "x",
+      parseLine: () => [],
+    };
+    const handle = makeFakeHandle([
+      { line: "noise", afterMs: 1 },
+      { line: "INIT:abc-123", afterMs: 1 },
+      { line: "INIT:should-not-overwrite", afterMs: 1 },
+    ]);
+    const invoker = makeProductionAgentInvoker({
+      agentProvider: provider,
+      handle,
+      onEvent: () => {},
+    });
+
+    const result = await runInvoke(invoker, { idleTimeoutSeconds: 60 });
+    expect(result.sessionId).toBe("abc-123");
+  });
+
+  test("agent without sessionCapture → result.sessionId stays undefined", async () => {
+    const handle = makeFakeHandle([{ line: "INIT:should-be-ignored", afterMs: 1 }]);
+    const invoker = makeProductionAgentInvoker({
+      agentProvider: makeFakeAgent(),
+      handle,
+      onEvent: () => {},
+    });
+    const result = await runInvoke(invoker, { idleTimeoutSeconds: 60 });
+    expect(result.sessionId).toBeUndefined();
   });
 });
 

--- a/packages/sanddune/src/internal/agent-invoker-live.ts
+++ b/packages/sanddune/src/internal/agent-invoker-live.ts
@@ -13,14 +13,17 @@ export function makeProductionAgentInvoker(params: {
   readonly onEvent: (event: AgentStreamEvent) => void;
 }): AgentInvokerService {
   return {
-    invoke: ({ prompt, iteration, signal, idleTimeoutSeconds }) =>
+    invoke: ({ prompt, iteration, signal, idleTimeoutSeconds, resumeSessionId }) =>
       Effect.tryPromise({
         try: async () => {
           const command = params.agentProvider.buildCommand({
             prompt,
             iteration,
+            ...(resumeSessionId !== undefined && { resumeSessionId }),
           });
           const events: AgentStreamEvent[] = [];
+          const sessionCapture = params.agentProvider.sessionCapture;
+          let sessionId: string | undefined;
 
           const idle = startIdleTimer({ idleTimeoutSeconds, iteration });
           const composite = composeSignals(signal, idle.signal);
@@ -29,6 +32,10 @@ export function makeProductionAgentInvoker(params: {
             const result = await params.handle.exec(command, {
               signal: composite,
               onLine: (line) => {
+                if (sessionCapture !== undefined && sessionId === undefined) {
+                  const id = sessionCapture.parseSessionId(line);
+                  if (id !== undefined) sessionId = id;
+                }
                 const parsed = params.agentProvider.parseLine(line, iteration);
                 if (parsed.length > 0) idle.reset();
                 for (const event of parsed) {
@@ -42,7 +49,10 @@ export function makeProductionAgentInvoker(params: {
                 `Agent exited with code ${result.exitCode}: ${result.stderr.trim()}`,
               );
             }
-            return { events };
+            return {
+              events,
+              ...(sessionId !== undefined && { sessionId }),
+            };
           } finally {
             idle.dispose();
           }

--- a/packages/sanddune/src/internal/iteration-loop.test.ts
+++ b/packages/sanddune/src/internal/iteration-loop.test.ts
@@ -499,6 +499,155 @@ describe("runIterationLoop", () => {
     });
   });
 
+  describe("resumeSessionId forwarding", () => {
+    test("resumeSessionId reaches invoker only on iteration 1; iteration 2+ get undefined", async () => {
+      const seen: { iteration: number; resumeSessionId: string | undefined }[] = [];
+      const invoker: AgentInvokerService = {
+        invoke: ({ iteration, resumeSessionId }) =>
+          Effect.tryPromise({
+            try: async () => {
+              seen.push({ iteration, resumeSessionId });
+              return { events: [textEvent("ok\n", iteration)] };
+            },
+            catch: (e) => (e instanceof Error ? e : new Error(String(e))),
+          }),
+      };
+      const { log } = makeFakeLogger();
+
+      await runLoop(
+        {
+          getPromptForIteration: async () => "go",
+          logger: log,
+          cwd: repo,
+          beforeSha: headSha(repo),
+          maxIterations: 3,
+          completionSignals: [],
+          idleTimeoutSeconds: NEVER_FIRES,
+          resumeSessionId: "session-XYZ",
+        },
+        invoker,
+      );
+
+      expect(seen).toEqual([
+        { iteration: 1, resumeSessionId: "session-XYZ" },
+        { iteration: 2, resumeSessionId: undefined },
+        { iteration: 3, resumeSessionId: undefined },
+      ]);
+    });
+  });
+
+  describe("captureSession integration", () => {
+    test("happy path: invoker emits sessionId → captureSession called → IterationResult.sessionId + sessionFilePath populated", async () => {
+      const captureCalls: { iteration: number; sessionId: string }[] = [];
+      const invoker: AgentInvokerService = {
+        invoke: ({ iteration }) =>
+          Effect.tryPromise({
+            try: async () => ({
+              events: [textEvent("ok\n", iteration)],
+              sessionId: `sid-${iteration}`,
+            }),
+            catch: (e) => (e instanceof Error ? e : new Error(String(e))),
+          }),
+      };
+      const { log } = makeFakeLogger();
+
+      const result = await runLoop(
+        {
+          getPromptForIteration: async () => "go",
+          logger: log,
+          cwd: repo,
+          beforeSha: headSha(repo),
+          maxIterations: 2,
+          completionSignals: [],
+          idleTimeoutSeconds: NEVER_FIRES,
+          captureSession: async ({ iteration, sessionId }) => {
+            captureCalls.push({ iteration, sessionId });
+            return `/host/sessions/${sessionId}.jsonl`;
+          },
+        },
+        invoker,
+      );
+
+      expect(captureCalls).toEqual([
+        { iteration: 1, sessionId: "sid-1" },
+        { iteration: 2, sessionId: "sid-2" },
+      ]);
+      expect(result.iterations[0]?.sessionId).toBe("sid-1");
+      expect(result.iterations[0]?.sessionFilePath).toBe(
+        "/host/sessions/sid-1.jsonl",
+      );
+      expect(result.iterations[1]?.sessionId).toBe("sid-2");
+      expect(result.iterations[1]?.sessionFilePath).toBe(
+        "/host/sessions/sid-2.jsonl",
+      );
+    });
+
+    test("capture failure (closure returns undefined) → sessionId still surfaced; sessionFilePath stays undefined; loop succeeds", async () => {
+      const invoker: AgentInvokerService = {
+        invoke: ({ iteration }) =>
+          Effect.tryPromise({
+            try: async () => ({
+              events: [textEvent("ok\n", iteration)],
+              sessionId: "sid-1",
+            }),
+            catch: (e) => (e instanceof Error ? e : new Error(String(e))),
+          }),
+      };
+      const { log } = makeFakeLogger();
+
+      const result = await runLoop(
+        {
+          getPromptForIteration: async () => "go",
+          logger: log,
+          cwd: repo,
+          beforeSha: headSha(repo),
+          maxIterations: 1,
+          completionSignals: [],
+          idleTimeoutSeconds: NEVER_FIRES,
+          captureSession: async () => undefined,
+        },
+        invoker,
+      );
+
+      expect(result.iterations).toHaveLength(1);
+      expect(result.iterations[0]?.sessionId).toBe("sid-1");
+      expect(result.iterations[0]?.sessionFilePath).toBeUndefined();
+    });
+
+    test("invoker returns no sessionId → captureSession is never called", async () => {
+      let captureInvoked = 0;
+      const invoker: AgentInvokerService = {
+        invoke: () =>
+          Effect.tryPromise({
+            try: async () => ({ events: [textEvent("ok\n", 1)] }),
+            catch: (e) => (e instanceof Error ? e : new Error(String(e))),
+          }),
+      };
+      const { log } = makeFakeLogger();
+
+      const result = await runLoop(
+        {
+          getPromptForIteration: async () => "go",
+          logger: log,
+          cwd: repo,
+          beforeSha: headSha(repo),
+          maxIterations: 1,
+          completionSignals: [],
+          idleTimeoutSeconds: NEVER_FIRES,
+          captureSession: async () => {
+            captureInvoked += 1;
+            return "/should/not/be/used";
+          },
+        },
+        invoker,
+      );
+
+      expect(captureInvoked).toBe(0);
+      expect(result.iterations[0]?.sessionId).toBeUndefined();
+      expect(result.iterations[0]?.sessionFilePath).toBeUndefined();
+    });
+  });
+
   describe("caller-supplied signal", () => {
     test("pre-aborted signal → loop rejects with reason; invoker is never called", async () => {
       const { invoker, calls } = makeScriptedInvoker([

--- a/packages/sanddune/src/internal/iteration-loop.ts
+++ b/packages/sanddune/src/internal/iteration-loop.ts
@@ -29,6 +29,20 @@ export interface IterationLoopInput {
    *  `spawnHost` SIGTERM) and rejects with `signal.reason` verbatim
    *  (ADR-0004 / ADR-0011). */
   readonly signal?: AbortSignal;
+  /** **Agent session** id to resume. Forwarded to the **agent invoker** on
+   *  iteration 1 only; subsequent iterations always start fresh per the
+   *  brief (slice #14 — long-lived sandboxes don't chain Claude session
+   *  state through `--resume`). */
+  readonly resumeSessionId?: string;
+  /** Best-effort capture closure invoked after each iteration whose invoke
+   *  returned a `sessionId`. Returns the absolute host path on success,
+   *  `undefined` if capture failed (the closure handles its own logging).
+   *  Omitted when the agent provider has no `sessionCapture` capability or
+   *  capture is disabled — in that case the loop never asks. */
+  readonly captureSession?: (input: {
+    readonly iteration: number;
+    readonly sessionId: string;
+  }) => Promise<string | undefined>;
 }
 
 export interface IterationLoopResult {
@@ -61,11 +75,14 @@ export const runIterationLoop = (
 
       yield* fromPromise(() => input.logger.iterationStarted(iteration));
 
+      const resumeSessionId =
+        iteration === 1 ? input.resumeSessionId : undefined;
       const result = yield* invoker.invoke({
         prompt: promptForIteration,
         iteration,
         idleTimeoutSeconds: input.idleTimeoutSeconds,
         ...(input.signal !== undefined && { signal: input.signal }),
+        ...(resumeSessionId !== undefined && { resumeSessionId }),
       });
 
       let signalMatched: string | undefined;
@@ -91,6 +108,19 @@ export const runIterationLoop = (
       const lastCommit = newCommits.at(-1) ?? null;
       if (lastCommit !== null) lastSha = lastCommit;
 
+      let sessionFilePath: string | undefined;
+      if (
+        input.captureSession !== undefined &&
+        result.sessionId !== undefined
+      ) {
+        sessionFilePath = yield* fromPromise(() =>
+          input.captureSession!({
+            iteration,
+            sessionId: result.sessionId!,
+          }),
+        );
+      }
+
       yield* fromPromise(() =>
         input.logger.iterationEnded(iteration, lastCommit),
       );
@@ -98,6 +128,8 @@ export const runIterationLoop = (
       iterations.push({
         iteration,
         ...(lastCommit !== null && { commitSha: lastCommit }),
+        ...(result.sessionId !== undefined && { sessionId: result.sessionId }),
+        ...(sessionFilePath !== undefined && { sessionFilePath }),
         ...(signalMatched !== undefined && { completionSignal: signalMatched }),
       });
 

--- a/packages/sanddune/src/internal/run-program.ts
+++ b/packages/sanddune/src/internal/run-program.ts
@@ -19,6 +19,11 @@ import {
 import { runIterationLoop } from "./iteration-loop";
 import { runEffect } from "./run-effect";
 import { openRunSession, type RunSession } from "./run-session";
+import {
+  makeCaptureSessionFn,
+  transferSessionToSandbox,
+  validateResumeSession,
+} from "./session-capture";
 import { createWorktreeStrategy } from "./worktree-strategy";
 
 /** Set to 1 so existing single-iteration callers don't get a cost multiplier
@@ -45,6 +50,22 @@ export async function runProgram(
 
   const provider = options.sandbox;
   const cwd = resolvePath(options.cwd ?? process.cwd());
+  const maxIterations = options.maxIterations ?? DEFAULT_MAX_ITERATIONS;
+
+  // Validates RESUME options on the **host** before any sandbox/worktree
+  // side effects: bad combos (resume + maxIterations > 1) and a missing
+  // host session file should fail fast, not after a stray container has
+  // already been spun up. Non-Claude agents have no `sessionCapture` and
+  // are silently ignored here.
+  if (options.resumeSession !== undefined) {
+    await validateResumeSession({
+      resumeSession: options.resumeSession,
+      agent: options.agent,
+      hostCwd: cwd,
+      maxIterations,
+    });
+  }
+
   const env = await resolveEnv({
     processEnv: process.env,
     sandduneEnvPath: join(cwd, ".sanddune", ".env"),
@@ -118,6 +139,23 @@ export async function runProgram(
       env,
     });
 
+    // Resume must happen after the sandbox exists (we write into it via
+    // `exec`) but before any iteration runs (so iteration 1's `--resume`
+    // points at a session file that already lives at the in-sandbox path
+    // Claude Code expects). Non-Claude agents lack `sessionCapture` and
+    // are skipped — the option was already validated above.
+    if (
+      options.resumeSession !== undefined &&
+      options.agent.sessionCapture !== undefined
+    ) {
+      await transferSessionToSandbox({
+        handle,
+        capture: options.agent.sessionCapture,
+        hostCwd: cwd,
+        sessionId: options.resumeSession,
+      });
+    }
+
     await runOnSandboxReadyParallel({
       hostHooks: options.hooks?.host?.onSandboxReady,
       sandboxHooks: options.hooks?.sandbox?.onSandboxReady,
@@ -136,6 +174,12 @@ export async function runProgram(
         }),
       );
 
+    const captureSession = makeCaptureSessionFn({
+      handle,
+      agent: options.agent,
+      hostCwd: cwd,
+    });
+
     const loopResult = await runEffect(
       runIterationLoop({
         getPromptForIteration: () =>
@@ -143,11 +187,16 @@ export async function runProgram(
         logger: session.logger,
         cwd: strategy.worktreePath,
         beforeSha,
-        maxIterations: options.maxIterations ?? DEFAULT_MAX_ITERATIONS,
+        maxIterations,
         completionSignals: normalizeCompletionSignals(options.completionSignal),
         idleTimeoutSeconds:
           options.idleTimeoutSeconds ?? DEFAULT_IDLE_TIMEOUT_SECONDS,
         ...(options.signal !== undefined && { signal: options.signal }),
+        ...(options.resumeSession !== undefined &&
+          options.agent.sessionCapture !== undefined && {
+            resumeSessionId: options.resumeSession,
+          }),
+        ...(captureSession !== undefined && { captureSession }),
       }).pipe(Effect.provide(agentInvokerLayer)),
     );
 

--- a/packages/sanddune/src/internal/session-capture.test.ts
+++ b/packages/sanddune/src/internal/session-capture.test.ts
@@ -1,0 +1,261 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import type {
+  AgentProvider,
+  AgentSessionCapture,
+  BindMountSandboxHandle,
+  ExecOptions,
+  ExecResult,
+} from "../core";
+import {
+  makeCaptureSessionFn,
+  transferSessionToSandbox,
+  validateResumeSession,
+} from "./session-capture";
+
+/** A capture impl with no real Claude Code coupling — paths root at the
+ *  caller-provided base dirs so tests can point them at tmpdirs. */
+function makeFakeCapture(opts: {
+  hostBase: string;
+  sandboxBase: string;
+}): AgentSessionCapture {
+  return {
+    parseSessionId: () => undefined,
+    hostSessionPath: (_hostCwd, sessionId) =>
+      `${opts.hostBase}/sessions/${sessionId}.jsonl`,
+    sandboxSessionPath: (_sandboxCwd, sessionId) =>
+      `${opts.sandboxBase}/${sessionId}.jsonl`,
+    rewriteCwd: (jsonl, fromCwd, toCwd) =>
+      jsonl.replaceAll(`"cwd":"${fromCwd}"`, `"cwd":"${toCwd}"`),
+  };
+}
+
+function fakeAgent(capture?: AgentSessionCapture): AgentProvider {
+  return {
+    name: "fake",
+    buildCommand: () => "x",
+    parseLine: () => [],
+    ...(capture !== undefined && { sessionCapture: capture }),
+  };
+}
+
+interface ExecCall {
+  readonly command: string;
+  readonly options?: ExecOptions;
+}
+interface FakeHandleOptions {
+  readonly worktreePath?: string;
+  readonly onExec: (
+    command: string,
+    options?: ExecOptions,
+  ) => Promise<ExecResult>;
+}
+function makeFakeHandle(
+  opts: FakeHandleOptions,
+): { readonly handle: BindMountSandboxHandle; readonly calls: ExecCall[] } {
+  const calls: ExecCall[] = [];
+  return {
+    handle: {
+      worktreePath: opts.worktreePath ?? "/workspace",
+      exec: async (command, options) => {
+        calls.push({ command, ...(options !== undefined && { options }) });
+        return opts.onExec(command, options);
+      },
+      close: async () => {},
+    },
+    calls,
+  };
+}
+
+describe("validateResumeSession", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "sanddune-session-validate-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("agent without sessionCapture → silently no-op (non-Claude providers ignore resume)", async () => {
+    await expect(
+      validateResumeSession({
+        resumeSession: "abc",
+        agent: fakeAgent(),
+        hostCwd: "/anywhere",
+        maxIterations: 1,
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  test("maxIterations > 1 → throws even before the file is checked", async () => {
+    const capture = makeFakeCapture({ hostBase: dir, sandboxBase: "/sb" });
+    await expect(
+      validateResumeSession({
+        resumeSession: "abc",
+        agent: fakeAgent(capture),
+        hostCwd: "/host",
+        maxIterations: 2,
+      }),
+    ).rejects.toThrow(/incompatible with maxIterations > 1.*got 2/);
+  });
+
+  test("missing host file → throws with the path", async () => {
+    const capture = makeFakeCapture({ hostBase: dir, sandboxBase: "/sb" });
+    const expectedPath = `${dir}/sessions/missing-id.jsonl`;
+    await expect(
+      validateResumeSession({
+        resumeSession: "missing-id",
+        agent: fakeAgent(capture),
+        hostCwd: "/host",
+        maxIterations: 1,
+      }),
+    ).rejects.toThrow(
+      new RegExp(`resumeSession "missing-id" not found at ${expectedPath}`),
+    );
+  });
+
+  test("happy path: file exists and maxIterations=1 → resolves", async () => {
+    const capture = makeFakeCapture({ hostBase: dir, sandboxBase: "/sb" });
+    await mkdir(join(dir, "sessions"), { recursive: true });
+    await writeFile(join(dir, "sessions", "abc.jsonl"), "{}\n");
+    await expect(
+      validateResumeSession({
+        resumeSession: "abc",
+        agent: fakeAgent(capture),
+        hostCwd: "/host",
+        maxIterations: 1,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe("transferSessionToSandbox", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "sanddune-session-transfer-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("reads host file, rewrites cwd host→sandbox, writes via mkdir+base64 to sandbox path", async () => {
+    const capture = makeFakeCapture({ hostBase: dir, sandboxBase: "/sb" });
+    await mkdir(join(dir, "sessions"), { recursive: true });
+    const hostJsonl =
+      `{"type":"user","cwd":"/host"}\n` + `{"type":"assistant","cwd":"/host"}\n`;
+    await writeFile(join(dir, "sessions", "abc.jsonl"), hostJsonl);
+
+    const { handle, calls } = makeFakeHandle({
+      onExec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+    });
+
+    await transferSessionToSandbox({
+      handle,
+      capture,
+      hostCwd: "/host",
+      sessionId: "abc",
+    });
+
+    expect(calls).toHaveLength(1);
+    const cmd = calls[0]!.command;
+    // mkdir uses the dirname of the sandbox path
+    expect(cmd.startsWith("mkdir -p /sb ")).toBe(true);
+    // base64 decode redirects into the sandbox path
+    expect(cmd.endsWith("> /sb/abc.jsonl")).toBe(true);
+    // The base64 payload decodes to the rewritten JSONL
+    const m = cmd.match(/printf '%s' '([^']+)' \| base64 -d/);
+    expect(m).not.toBeNull();
+    const decoded = Buffer.from(m![1]!, "base64").toString("utf8");
+    expect(decoded).toContain(`"cwd":"/workspace"`);
+    expect(decoded).not.toContain(`"cwd":"/host"`);
+  });
+
+  test("non-zero exec exit propagates as an error (resume failure is not best-effort)", async () => {
+    const capture = makeFakeCapture({ hostBase: dir, sandboxBase: "/sb" });
+    await mkdir(join(dir, "sessions"), { recursive: true });
+    await writeFile(join(dir, "sessions", "abc.jsonl"), "{}\n");
+
+    const { handle } = makeFakeHandle({
+      onExec: async () => ({ stdout: "", stderr: "boom", exitCode: 5 }),
+    });
+
+    await expect(
+      transferSessionToSandbox({
+        handle,
+        capture,
+        hostCwd: "/host",
+        sessionId: "abc",
+      }),
+    ).rejects.toThrow(/exited 5.*boom/);
+  });
+});
+
+describe("makeCaptureSessionFn", () => {
+  let dir: string;
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "sanddune-session-capture-"));
+  });
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  test("returns undefined when the agent has no sessionCapture", () => {
+    const { handle } = makeFakeHandle({
+      onExec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+    });
+    expect(
+      makeCaptureSessionFn({ handle, agent: fakeAgent(), hostCwd: "/host" }),
+    ).toBeUndefined();
+  });
+
+  test("happy path: cats sandbox file, rewrites sandbox→host, writes to host path, returns host path", async () => {
+    const capture = makeFakeCapture({ hostBase: dir, sandboxBase: "/sb" });
+    const sandboxJsonl =
+      `{"type":"user","cwd":"/workspace"}\n` +
+      `{"type":"assistant","cwd":"/workspace"}\n`;
+    const { handle, calls } = makeFakeHandle({
+      onExec: async (command) => {
+        if (command.startsWith("cat ")) {
+          return { stdout: sandboxJsonl, stderr: "", exitCode: 0 };
+        }
+        return { stdout: "", stderr: "", exitCode: 0 };
+      },
+    });
+
+    const fn = makeCaptureSessionFn({
+      handle,
+      agent: fakeAgent(capture),
+      hostCwd: "/host",
+    });
+    expect(fn).toBeDefined();
+
+    const hostPath = await fn!({ iteration: 1, sessionId: "abc" });
+
+    const expectedPath = `${dir}/sessions/abc.jsonl`;
+    expect(hostPath).toBe(expectedPath);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.command).toBe("cat /sb/abc.jsonl");
+
+    const written = await readFile(expectedPath, "utf8");
+    // cwd rewritten sandbox → host
+    expect(written).toContain(`"cwd":"/host"`);
+    expect(written).not.toContain(`"cwd":"/workspace"`);
+  });
+
+  test("read failure → returns undefined, run still proceeds (best-effort capture)", async () => {
+    const capture = makeFakeCapture({ hostBase: dir, sandboxBase: "/sb" });
+    const { handle } = makeFakeHandle({
+      onExec: async () => ({ stdout: "", stderr: "no such file", exitCode: 1 }),
+    });
+
+    const fn = makeCaptureSessionFn({
+      handle,
+      agent: fakeAgent(capture),
+      hostCwd: "/host",
+    });
+    const result = await fn!({ iteration: 2, sessionId: "abc" });
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/sanddune/src/internal/session-capture.ts
+++ b/packages/sanddune/src/internal/session-capture.ts
@@ -1,0 +1,154 @@
+import { dirname } from "node:path";
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import type {
+  AgentProvider,
+  AgentSessionCapture,
+  BindMountSandboxHandle,
+} from "../core";
+
+/** Validates `RunOptions.resumeSession` BEFORE the sandbox is created. The
+ *  early-throw contract matters because sandbox creation is expensive and
+ *  side-effectful (a stray container/worktree is harder to clean up than a
+ *  rejected `run()`).
+ *
+ *  Two failure modes — both throw a plain `Error`:
+ *  - `maxIterations > 1`: long-lived iteration loops can't chain Claude
+ *    session state through `--resume`, so the combination is rejected
+ *    rather than silently ignoring one of the options.
+ *  - host session file missing: `claude --resume` would fail later with a
+ *    less-actionable error; we surface it up front.
+ *
+ *  Non-Claude **agent providers** (no `sessionCapture` capability) opt out
+ *  entirely — `resumeSession` is silently dropped per the brief. */
+export async function validateResumeSession(input: {
+  readonly resumeSession: string;
+  readonly agent: AgentProvider;
+  readonly hostCwd: string;
+  readonly maxIterations: number;
+}): Promise<void> {
+  const capture = input.agent.sessionCapture;
+  if (capture === undefined) return;
+  if (input.maxIterations > 1) {
+    throw new Error(
+      `resumeSession is incompatible with maxIterations > 1 (got ${input.maxIterations}). ` +
+        `Resuming a Claude agent session is a fresh-sandbox concern; only iteration 1 receives --resume.`,
+    );
+  }
+  const hostPath = capture.hostSessionPath(input.hostCwd, input.resumeSession);
+  try {
+    const s = await stat(hostPath);
+    if (!s.isFile()) {
+      throw new Error(`not a file: ${hostPath}`);
+    }
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(
+      `resumeSession "${input.resumeSession}" not found at ${hostPath}: ${msg}`,
+    );
+  }
+}
+
+/** Transfers a host session JSONL into a live **sandbox** at the path the
+ *  **agent** expects, with `cwd` fields rewritten from the **host** repo
+ *  root to the sandbox-side worktree path. Called once after sandbox
+ *  creation, before iteration 1.
+ *
+ *  Failure here is fatal — unlike capture, resume is something the user
+ *  explicitly requested and a partial transfer would silently start a
+ *  fresh session. We let the error propagate and `run()`'s teardown
+ *  cleans up. */
+export async function transferSessionToSandbox(input: {
+  readonly handle: BindMountSandboxHandle;
+  readonly capture: AgentSessionCapture;
+  readonly hostCwd: string;
+  readonly sessionId: string;
+}): Promise<void> {
+  const { handle, capture, hostCwd, sessionId } = input;
+  const hostPath = capture.hostSessionPath(hostCwd, sessionId);
+  const sandboxPath = capture.sandboxSessionPath(handle.worktreePath, sessionId);
+  const original = await readFile(hostPath, "utf8");
+  const rewritten = capture.rewriteCwd(original, hostCwd, handle.worktreePath);
+  await writeFileInSandbox(handle, sandboxPath, rewritten);
+}
+
+/** Builds the best-effort capture closure handed to the **iteration loop**.
+ *  Returns `undefined` when the agent has no `sessionCapture` capability —
+ *  the loop then never asks. */
+export function makeCaptureSessionFn(input: {
+  readonly handle: BindMountSandboxHandle;
+  readonly agent: AgentProvider;
+  readonly hostCwd: string;
+}):
+  | ((args: {
+      readonly iteration: number;
+      readonly sessionId: string;
+    }) => Promise<string | undefined>)
+  | undefined {
+  const capture = input.agent.sessionCapture;
+  if (capture === undefined) return undefined;
+  return async ({ iteration, sessionId }) => {
+    try {
+      const sandboxPath = capture.sandboxSessionPath(
+        input.handle.worktreePath,
+        sessionId,
+      );
+      const raw = await readFileFromSandbox(input.handle, sandboxPath);
+      const rewritten = capture.rewriteCwd(
+        raw,
+        input.handle.worktreePath,
+        input.hostCwd,
+      );
+      const hostPath = capture.hostSessionPath(input.hostCwd, sessionId);
+      await mkdir(dirname(hostPath), { recursive: true });
+      await writeFile(hostPath, rewritten);
+      return hostPath;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      process.stderr.write(
+        `sanddune: agent session capture failed for iteration ${iteration} (session ${sessionId}): ${msg}\n`,
+      );
+      return undefined;
+    }
+  };
+}
+
+/** Reads a sandbox file by `cat`-ing it and capturing stdout. The path may
+ *  begin with `~` (shell expands it inside the sandbox); leave unquoted. */
+async function readFileFromSandbox(
+  handle: BindMountSandboxHandle,
+  sandboxPath: string,
+): Promise<string> {
+  const result = await handle.exec(`cat ${sandboxPath}`);
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `cat ${sandboxPath} exited ${result.exitCode}: ${result.stderr.trim()}`,
+    );
+  }
+  return result.stdout;
+}
+
+/** Writes content to a sandbox file via `printf '%s' '<b64>' | base64 -d`.
+ *  Base64 sidesteps shell-quoting concerns for arbitrary JSONL bytes; the
+ *  surrounding `mkdir -p` ensures the project dir exists. As with read,
+ *  the sandbox path may begin with `~` and must stay unquoted. */
+async function writeFileInSandbox(
+  handle: BindMountSandboxHandle,
+  sandboxPath: string,
+  content: string,
+): Promise<void> {
+  const lastSlash = sandboxPath.lastIndexOf("/");
+  if (lastSlash <= 0) {
+    throw new Error(
+      `sandbox session path must contain a directory component: ${sandboxPath}`,
+    );
+  }
+  const sandboxDir = sandboxPath.slice(0, lastSlash);
+  const b64 = Buffer.from(content, "utf8").toString("base64");
+  const command = `mkdir -p ${sandboxDir} && printf '%s' '${b64}' | base64 -d > ${sandboxPath}`;
+  const result = await handle.exec(command);
+  if (result.exitCode !== 0) {
+    throw new Error(
+      `writing ${sandboxPath} exited ${result.exitCode}: ${result.stderr.trim()}`,
+    );
+  }
+}


### PR DESCRIPTION
Closes #14.

## Summary

- After each iteration with `claudeCode()` (default `captureSessions: true`), the session JSONL is captured from the sandbox to `~/.claude/projects/<encoded-cwd>/sessions/<id>.jsonl` on the host with `cwd` fields rewritten so `claude --resume` works natively. `IterationResult.sessionId` and `sessionFilePath` are populated on success. **Capture is best-effort** — failure logs a warning to stderr and leaves `sessionFilePath` undefined; the run still resolves successfully.
- `RunOptions.resumeSession: "<id>"` validates the host file exists, transfers it into the sandbox with `cwd` rewritten to the worktree path, and passes `--resume <id>` to Claude Code on iteration 1 only. Validation runs **before** sandbox creation: `resumeSession + maxIterations > 1` throws, and a missing host file throws.
- New optional `AgentProvider.sessionCapture` capability keeps capture/resume agent-aware. Non-Claude providers omit it and both options become no-ops with no errors.
- Internals: new `internal/session-capture.ts` owns validation, transfer-in (`mkdir + base64 -d` over the existing `exec` API), and the best-effort capture closure handed to the iteration loop. `agent-invoker-live` forwards `resumeSessionId` to `buildCommand` and surfaces the parsed `sessionId` from the stream. `iteration-loop` passes `resumeSessionId` only on iteration 1 and calls capture only when the invoker emitted a session id.

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test` — 181 pass / 0 fail (was 148; +33 new)
- [x] `bun run build` — `.d.ts` generation clean
- [x] Unit coverage per the issue acceptance criteria:
  - capture happy path (`session-capture.test.ts`, `iteration-loop.test.ts`)
  - capture failure → warning + run still resolves (`session-capture.test.ts`, `iteration-loop.test.ts`)
  - `resumeSession` missing-file validation throws (`session-capture.test.ts`)
  - `resumeSession + maxIterations > 1` throws before sandbox creation (`session-capture.test.ts`)
  - `cwd` rewrite both directions (`claude-code.test.ts`)
  - `--resume <id>` only on iteration 1 (`iteration-loop.test.ts`)
  - `captureSessions: false` opt-out (`claude-code.test.ts`)
  - non-Claude provider (no `sessionCapture`) → resume is silent no-op (`session-capture.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)