### PR TITLE
feat: createSandbox() reusable sandbox + await using

### DIFF
--- a/.changeset/create-sandbox-reusable.md
+++ b/.changeset/create-sandbox-reusable.md
@@ -1,0 +1,17 @@
+---
+"@missingstudio/sanddune": patch
+---
+
+Implement top-level `createSandbox()` — a long-lived reusable **sandbox** on a single branch.
+
+`createSandbox({ agent, sandbox, branch, cwd?, env?, hooks?, copyToWorktree?, timeouts?, logging? })` returns a `Sandbox` handle that owns both **worktree** and container per ADR-0010. Multiple `sandbox.run()` calls accumulate commits on the same **branch**; the container is reused across calls (no restart cost). Lifecycle **hooks** and `copyToWorktree` run once at creation time, not per `sandbox.run()`.
+
+`sandbox.run(options)` accepts `SandboxRunOptions` — `RunOptions` minus the inherited fields (`cwd`, `branchStrategy`, `copyToWorktree`, `hooks`, `timeouts`) and minus `resumeSession`. `resumeSession` is rejected at the type level **and** at runtime — Claude **agent session** chaining is a fresh-sandbox concern only.
+
+`sandbox.close()` returns `CloseResult` with `preservedWorktreePath` set when the worktree was dirty at close. The top-level `createSandbox()`'s `close()` tears down both container AND worktree (ownership-follows-creation).
+
+`Sandbox` now exposes `branch`, `worktreePath`, `run(options)`, `interactive(options)`, `close()`, and `[Symbol.asyncDispose]` — `await using sandbox = await createSandbox(...)` auto-disposes on block exit, even when an exception escapes. `sandbox.exec()` was removed from the public surface (the underlying `BindMountSandboxHandle.exec` is still available to internal code).
+
+`sandbox.run()` survives mid-iteration abort: a per-call `signal` firing during a run leaves the handle usable for a follow-up `.run()` or `.close()` (per ADR-0011).
+
+The lifecycle is shared with the next slice via an internal `createSandboxFromWorktree` helper that `wt.createSandbox()` will reuse.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ A TypeScript library for orchestrating AI coding agents in isolated sandboxes.
 | `onAgentStreamEvent` callback        | ✅ shipped | Sync, fire-and-forget; errors swallowed (file mode only)                         |
 | `IterationResult.usage`              | ✅ shipped | Raw token counts parsed from captured Claude session JSONL (per ADR-0005b)       |
 | Custom bind-mount provider           | ✅ shipped | Build your own by constructing a `BindMountSandboxProvider` |
+| `createSandbox()`                   | ✅ shipped | Long-lived reusable sandbox on a single branch; multiple `sandbox.run()` calls reuse the container; `await using` auto-disposes |
 
 ## Quick start
 

--- a/packages/sanddune/src/core/index.ts
+++ b/packages/sanddune/src/core/index.ts
@@ -70,6 +70,7 @@ export type {
   CloseResult,
   CreateSandboxOptions,
   Sandbox,
+  SandboxInteractiveOptions,
   SandboxRunOptions,
 } from "./sandbox";
 

--- a/packages/sanddune/src/core/sandbox.ts
+++ b/packages/sanddune/src/core/sandbox.ts
@@ -4,7 +4,6 @@ import type { LoggingOption } from "./logging";
 import type { PromptOption } from "./prompt";
 import type {
   CreateSandboxProvider,
-  ExecResult,
 } from "./sandbox-provider";
 import type { Timeouts } from "./timeouts";
 import type { RunResult } from "./run";
@@ -23,6 +22,11 @@ export interface CreateSandboxOptions<
   readonly copyToWorktree?: readonly string[];
 }
 
+/** Per-call options for `sandbox.run()`. Equals top-level `RunOptions` minus
+ *  the fields that are inherited from `createSandbox()` (`cwd`,
+ *  `branchStrategy`, `copyToWorktree`, `hooks`, `timeouts`) and minus
+ *  `resumeSession` — Claude **agent session** chaining is a fresh-sandbox
+ *  concern only (per #14, ADR / CONTEXT). */
 export type SandboxRunOptions = PromptOption & {
   readonly maxIterations?: number;
   readonly completionSignal?: string | readonly string[];
@@ -30,17 +34,29 @@ export type SandboxRunOptions = PromptOption & {
   readonly env?: Readonly<Record<string, string>>;
   readonly logging?: LoggingOption;
   readonly signal?: AbortSignal;
+  /** Rejected at the type level — see SandboxRunOptions docstring. */
+  readonly resumeSession?: never;
+};
+
+export type SandboxInteractiveOptions = PromptOption & {
+  readonly env?: Readonly<Record<string, string>>;
 };
 
 export interface CloseResult {
   readonly worktreePreserved: boolean;
-  readonly worktreePath?: string;
+  /** Set only when the worktree was dirty at close — per #5, dirty worktrees
+   *  are preserved on disk so the user can recover work; clean worktrees are
+   *  removed. Always `undefined` when the **sandbox** was created via
+   *  `wt.createSandbox()` (worktree ownership lives with the parent
+   *  `Worktree`, not the sandbox — ADR-0010). */
+  readonly preservedWorktreePath?: string;
 }
 
 export interface Sandbox {
   readonly branch: string;
   readonly worktreePath: string;
   run(options: SandboxRunOptions): Promise<RunResult>;
-  exec(command: string, options?: { sudo?: boolean }): Promise<ExecResult>;
+  interactive(options: SandboxInteractiveOptions): Promise<void>;
   close(): Promise<CloseResult>;
+  [Symbol.asyncDispose](): Promise<void>;
 }

--- a/packages/sanddune/src/create-sandbox.integration.test.ts
+++ b/packages/sanddune/src/create-sandbox.integration.test.ts
@@ -1,0 +1,471 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import {
+  AgentInvoker,
+  type AgentInvokerService,
+  type AgentProvider,
+  type BindMountSandboxHandle,
+  type BindMountSandboxProvider,
+} from "./core";
+import { createSandboxProgram } from "./internal/create-sandbox-program";
+
+describe("createSandbox (integration)", () => {
+  let repo: string;
+
+  beforeEach(async () => {
+    repo = await mkdtemp(join(tmpdir(), "sanddune-cs-"));
+    runSync("git", ["init", "--initial-branch=main"], repo);
+    runSync("git", ["config", "user.email", "test@example.com"], repo);
+    runSync("git", ["config", "user.name", "test"], repo);
+    runSync("git", ["config", "commit.gpgsign", "false"], repo);
+    await writeFile(join(repo, "README.md"), "seed\n");
+    runSync("git", ["add", "."], repo);
+    runSync("git", ["commit", "-m", "seed"], repo);
+  });
+
+  afterEach(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  test("multiple sandbox.run() calls accumulate commits on the same branch and reuse the same container", async () => {
+    const closeCalls: number[] = [];
+    const createCalls: number[] = [];
+    const provider = makeBindMountProvider({ closeCalls, createCalls });
+    const agent: AgentProvider = {
+      name: "stub",
+      buildCommand: () => "true",
+      parseLine: () => [],
+    };
+
+    const handleRef: { current: BindMountSandboxHandle | undefined } = {
+      current: undefined,
+    };
+    const fakeInvoker = scriptedAgent(handleRef, [
+      "printf 'one\\n' > a.txt && git add a.txt && git -c user.email=agent@example.com -c user.name=agent -c commit.gpgsign=false commit -m 'first'",
+      "printf 'two\\n' > b.txt && git add b.txt && git -c user.email=agent@example.com -c user.name=agent -c commit.gpgsign=false commit -m 'second'",
+    ]);
+
+    const sandbox = await createSandboxProgram(
+      {
+        agent,
+        sandbox: capturing(provider, handleRef),
+        branch: "agent/feat",
+        cwd: repo,
+      },
+      { agentInvokerLayer: Layer.succeed(AgentInvoker, fakeInvoker.invoker) },
+    );
+
+    expect(sandbox.branch).toBe("agent/feat");
+    expect(sandbox.worktreePath).toBe(
+      join(repo, ".sanddune", "worktrees", "agent-feat"),
+    );
+
+    const r1 = await sandbox.run({ prompt: "do A" });
+    expect(r1.commits).toHaveLength(1);
+    expect(r1.branch).toBe("agent/feat");
+
+    const r2 = await sandbox.run({ prompt: "do B" });
+    expect(r2.commits).toHaveLength(1);
+    expect(r2.branch).toBe("agent/feat");
+
+    // Container created exactly once across both runs.
+    expect(createCalls).toEqual([1]);
+    expect(closeCalls).toEqual([]);
+
+    // Branch tip carries both commits.
+    const branchLog = runSync(
+      "git",
+      ["log", "agent/feat", "--format=%s"],
+      repo,
+    ).stdout;
+    expect(branchLog).toContain("first");
+    expect(branchLog).toContain("second");
+
+    const closeResult = await sandbox.close();
+    expect(closeResult.worktreePreserved).toBe(false);
+    expect(closeResult.preservedWorktreePath).toBeUndefined();
+    expect(closeCalls).toEqual([1]);
+  });
+
+  test("await using auto-disposes on block exit (success)", async () => {
+    const closeCalls: number[] = [];
+    const provider = makeBindMountProvider({ closeCalls });
+    const agent: AgentProvider = {
+      name: "stub",
+      buildCommand: () => "true",
+      parseLine: () => [],
+    };
+
+    const handleRef: { current: BindMountSandboxHandle | undefined } = {
+      current: undefined,
+    };
+    const fakeInvoker = scriptedAgent(handleRef, [
+      "printf 'x\\n' > x.txt && git add x.txt && git -c user.email=agent@example.com -c user.name=agent -c commit.gpgsign=false commit -m 'x'",
+    ]);
+
+    {
+      await using sandbox = await createSandboxProgram(
+        {
+          agent,
+          sandbox: capturing(provider, handleRef),
+          branch: "agent/auto",
+          cwd: repo,
+        },
+        { agentInvokerLayer: Layer.succeed(AgentInvoker, fakeInvoker.invoker) },
+      );
+      const r = await sandbox.run({ prompt: "go" });
+      expect(r.commits).toHaveLength(1);
+    }
+
+    expect(closeCalls).toEqual([1]);
+    // Clean worktree should have been removed by close().
+    expect(existsSync(join(repo, ".sanddune", "worktrees", "agent-auto"))).toBe(
+      false,
+    );
+  });
+
+  test("await using auto-disposes even when an exception escapes the block", async () => {
+    const closeCalls: number[] = [];
+    const provider = makeBindMountProvider({ closeCalls });
+    const agent: AgentProvider = {
+      name: "stub",
+      buildCommand: () => "true",
+      parseLine: () => [],
+    };
+
+    const handleRef: { current: BindMountSandboxHandle | undefined } = {
+      current: undefined,
+    };
+    const failingInvoker: AgentInvokerService = {
+      invoke: () => Effect.fail(new Error("boom")),
+    };
+
+    await expect(
+      (async () => {
+        await using sandbox = await createSandboxProgram(
+          {
+            agent,
+            sandbox: capturing(provider, handleRef),
+            branch: "agent/throw",
+            cwd: repo,
+          },
+          { agentInvokerLayer: Layer.succeed(AgentInvoker, failingInvoker) },
+        );
+        await sandbox.run({ prompt: "explode" });
+      })(),
+    ).rejects.toThrow(/boom/);
+
+    expect(closeCalls).toEqual([1]);
+  });
+
+  test("dirty worktree is preserved on close; clean worktree is removed", async () => {
+    const closeCalls: number[] = [];
+    const provider = makeBindMountProvider({ closeCalls });
+    const agent: AgentProvider = {
+      name: "stub",
+      buildCommand: () => "true",
+      parseLine: () => [],
+    };
+
+    const handleRef: { current: BindMountSandboxHandle | undefined } = {
+      current: undefined,
+    };
+    const dirtyInvoker = scriptedAgent(handleRef, [
+      // Commit one file, then leave a second uncommitted to dirty the worktree.
+      "printf 'committed\\n' > committed.txt && git add committed.txt && git -c user.email=agent@example.com -c user.name=agent -c commit.gpgsign=false commit -m 'committed' && printf 'leftover\\n' > leftover.txt",
+    ]);
+
+    const sandbox = await createSandboxProgram(
+      {
+        agent,
+        sandbox: capturing(provider, handleRef),
+        branch: "agent/dirty",
+        cwd: repo,
+      },
+      { agentInvokerLayer: Layer.succeed(AgentInvoker, dirtyInvoker.invoker) },
+    );
+    await sandbox.run({ prompt: "leave a mess" });
+    const closeResult = await sandbox.close();
+
+    expect(closeResult.worktreePreserved).toBe(true);
+    expect(closeResult.preservedWorktreePath).toBe(
+      join(repo, ".sanddune", "worktrees", "agent-dirty"),
+    );
+    expect(existsSync(closeResult.preservedWorktreePath!)).toBe(true);
+    expect(
+      existsSync(join(closeResult.preservedWorktreePath!, "leftover.txt")),
+    ).toBe(true);
+  });
+
+  test("sandbox.run() rejects resumeSession at runtime", async () => {
+    const closeCalls: number[] = [];
+    const provider = makeBindMountProvider({ closeCalls });
+    const agent: AgentProvider = {
+      name: "stub",
+      buildCommand: () => "true",
+      parseLine: () => [],
+    };
+
+    const handleRef: { current: BindMountSandboxHandle | undefined } = {
+      current: undefined,
+    };
+    const noopInvoker: AgentInvokerService = {
+      invoke: () => Effect.succeed({ events: [] }),
+    };
+
+    await using sandbox = await createSandboxProgram(
+      {
+        agent,
+        sandbox: capturing(provider, handleRef),
+        branch: "agent/no-resume",
+        cwd: repo,
+      },
+      { agentInvokerLayer: Layer.succeed(AgentInvoker, noopInvoker) },
+    );
+
+    await expect(
+      sandbox.run({
+        prompt: "x",
+        resumeSession: "abc",
+      } as unknown as Parameters<typeof sandbox.run>[0]),
+    ).rejects.toThrow(/resumeSession/);
+  });
+
+  test("handle remains usable after a per-call abort — sandbox can run again, then close", async () => {
+    const closeCalls: number[] = [];
+    const provider = makeBindMountProvider({ closeCalls });
+    const agent: AgentProvider = {
+      name: "stub",
+      buildCommand: () => "true",
+      parseLine: () => [],
+    };
+
+    const handleRef: { current: BindMountSandboxHandle | undefined } = {
+      current: undefined,
+    };
+
+    let invocations = 0;
+    const invoker: AgentInvokerService = {
+      invoke: () =>
+        Effect.tryPromise({
+          try: async () => {
+            invocations += 1;
+            return { events: [] };
+          },
+          catch: (e) => (e instanceof Error ? e : new Error(String(e))),
+        }),
+    };
+
+    const sandbox = await createSandboxProgram(
+      {
+        agent,
+        sandbox: capturing(provider, handleRef),
+        branch: "agent/abort-rerun",
+        cwd: repo,
+      },
+      { agentInvokerLayer: Layer.succeed(AgentInvoker, invoker) },
+    );
+
+    // First call: pre-aborted signal — loop bails before invoking the agent.
+    const ac = new AbortController();
+    ac.abort(new Error("first run cancelled"));
+    await expect(
+      sandbox.run({ prompt: "first", signal: ac.signal }),
+    ).rejects.toThrow(/first run cancelled/);
+    expect(invocations).toBe(0);
+
+    // Sandbox handle survives — second call with a fresh signal succeeds.
+    const r = await sandbox.run({ prompt: "second" });
+    expect(r.iterations).toHaveLength(1);
+    expect(invocations).toBe(1);
+
+    // Close still works after the rerun.
+    const closeResult = await sandbox.close();
+    expect(closeCalls).toEqual([1]);
+    // Worktree is clean (no commits landed) — should be removed.
+    expect(closeResult.worktreePreserved).toBe(false);
+  });
+
+  test("creation hooks run once at construction time, not per sandbox.run()", async () => {
+    const closeCalls: number[] = [];
+    const provider = makeBindMountProvider({ closeCalls });
+    const agent: AgentProvider = {
+      name: "stub",
+      buildCommand: () => "true",
+      parseLine: () => [],
+    };
+
+    const handleRef: { current: BindMountSandboxHandle | undefined } = {
+      current: undefined,
+    };
+    const noopInvoker: AgentInvokerService = {
+      invoke: () => Effect.succeed({ events: [] }),
+    };
+
+    const hookFile = join(repo, "hook-marker.txt");
+    expect(existsSync(hookFile)).toBe(false);
+
+    await using sandbox = await createSandboxProgram(
+      {
+        agent,
+        sandbox: capturing(provider, handleRef),
+        branch: "agent/hooks",
+        cwd: repo,
+        hooks: {
+          host: {
+            onWorktreeReady: [
+              {
+                command: `printf 'tick\\n' >> ${hookFile.replace(/'/g, "'\\''")}`,
+              },
+            ],
+          },
+        },
+      },
+      { agentInvokerLayer: Layer.succeed(AgentInvoker, noopInvoker) },
+    );
+
+    await sandbox.run({ prompt: "first" });
+    await sandbox.run({ prompt: "second" });
+
+    const ticks = (await Bun.file(hookFile).text()).trim().split("\n");
+    expect(ticks).toEqual(["tick"]);
+  });
+
+  test("close() is idempotent — second call is a no-op", async () => {
+    const closeCalls: number[] = [];
+    const provider = makeBindMountProvider({ closeCalls });
+    const agent: AgentProvider = {
+      name: "stub",
+      buildCommand: () => "true",
+      parseLine: () => [],
+    };
+
+    const handleRef: { current: BindMountSandboxHandle | undefined } = {
+      current: undefined,
+    };
+    const noopInvoker: AgentInvokerService = {
+      invoke: () => Effect.succeed({ events: [] }),
+    };
+
+    const sandbox = await createSandboxProgram(
+      {
+        agent,
+        sandbox: capturing(provider, handleRef),
+        branch: "agent/idem",
+        cwd: repo,
+      },
+      { agentInvokerLayer: Layer.succeed(AgentInvoker, noopInvoker) },
+    );
+
+    await sandbox.close();
+    await sandbox.close();
+    expect(closeCalls).toEqual([1]);
+
+    // After close, calling run() throws.
+    await expect(sandbox.run({ prompt: "x" })).rejects.toThrow(
+      /after close/,
+    );
+  });
+});
+
+function makeBindMountProvider(input: {
+  readonly closeCalls: number[];
+  readonly createCalls?: number[];
+}): BindMountSandboxProvider {
+  const { closeCalls, createCalls } = input;
+  return {
+    kind: "bind-mount",
+    name: "local-process",
+    create: async ({ worktreePath }) => {
+      createCalls?.push(1);
+      return {
+        worktreePath,
+        exec: async (command, opts) => {
+          const result = spawnSync("sh", ["-c", command], {
+            cwd: opts?.cwd ?? worktreePath,
+            encoding: "utf8",
+          });
+          return {
+            stdout: result.stdout ?? "",
+            stderr: result.stderr ?? "",
+            exitCode: result.status ?? 0,
+          };
+        },
+        close: async () => {
+          closeCalls.push(1);
+        },
+      };
+    },
+  };
+}
+
+function capturing(
+  inner: BindMountSandboxProvider,
+  handleRef: { current: BindMountSandboxHandle | undefined },
+): BindMountSandboxProvider {
+  return {
+    kind: "bind-mount",
+    name: inner.name,
+    create: async (options) => {
+      const handle = await inner.create(options);
+      handleRef.current = handle;
+      return handle;
+    },
+  };
+}
+
+function scriptedAgent(
+  handleRef: { current: BindMountSandboxHandle | undefined },
+  scripts: readonly string[],
+): { invoker: AgentInvokerService } {
+  let i = 0;
+  return {
+    invoker: {
+      invoke: ({ iteration }) =>
+        Effect.tryPromise({
+          try: async () => {
+            const handle = handleRef.current;
+            if (!handle) throw new Error("handle not yet captured");
+            const script = scripts[i];
+            i += 1;
+            if (script === undefined) {
+              throw new Error(
+                `no scripted command for invocation ${i} (iteration ${iteration})`,
+              );
+            }
+            await handle.exec(script);
+            return {
+              events: [
+                {
+                  type: "text" as const,
+                  content: `iteration ${iteration} done\n`,
+                  iteration,
+                  timestamp: Date.now(),
+                },
+              ],
+            };
+          },
+          catch: (e) => (e instanceof Error ? e : new Error(String(e))),
+        }),
+    },
+  };
+}
+
+function runSync(
+  cmd: string,
+  args: readonly string[],
+  cwd: string,
+): { stdout: string; stderr: string } {
+  const r = spawnSync(cmd, args, { cwd, encoding: "utf8" });
+  if (r.status !== 0) {
+    throw new Error(
+      `${cmd} ${args.join(" ")} failed: ${r.stderr ?? ""}${r.stdout ?? ""}`,
+    );
+  }
+  return { stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}

--- a/packages/sanddune/src/index.test.ts
+++ b/packages/sanddune/src/index.test.ts
@@ -1,19 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { NotImplementedError } from "./core";
-import { createSandbox, createWorktree, interactive } from "./index";
+import { createWorktree, interactive } from "./index";
 import { docker } from "./sandboxes/docker";
 import { noSandbox } from "./sandboxes/no-sandbox";
 import { podman } from "./sandboxes/podman";
 import { vercel } from "./sandboxes/vercel";
 
 describe("entry-point stubs throw NotImplementedError", () => {
-  test("createSandbox", () => {
-    expect(() => createSandbox({} as never)).toThrow(NotImplementedError);
-    expect(() => createSandbox({} as never)).toThrow(
-      /^createSandbox is not implemented$/,
-    );
-  });
-
   test("createWorktree", () => {
     expect(() => createWorktree()).toThrow(NotImplementedError);
     expect(() => createWorktree()).toThrow(

--- a/packages/sanddune/src/index.ts
+++ b/packages/sanddune/src/index.ts
@@ -11,6 +11,7 @@ import type {
   Sandbox,
   Worktree,
 } from "./core";
+import { createSandboxProgram } from "./internal/create-sandbox-program";
 import { runProgram } from "./internal/run-program";
 
 export * from "./core";
@@ -23,9 +24,11 @@ export function run<S extends RunSandboxProvider>(
 }
 
 export function createSandbox<S extends CreateSandboxProvider>(
-  _options: CreateSandboxOptions<S>,
+  options: CreateSandboxOptions<S>,
 ): Promise<Sandbox> {
-  throw new NotImplementedError("createSandbox");
+  return createSandboxProgram(
+    options as CreateSandboxOptions<CreateSandboxProvider>,
+  );
 }
 
 export function createWorktree(

--- a/packages/sanddune/src/internal/create-sandbox-program.ts
+++ b/packages/sanddune/src/internal/create-sandbox-program.ts
@@ -1,0 +1,64 @@
+import { join, resolve as resolvePath } from "node:path";
+import {
+  type CreateSandboxOptions,
+  type CreateSandboxProvider,
+  type Sandbox,
+} from "../core";
+import {
+  createSandboxFromWorktree,
+  type CreateSandboxSeams,
+} from "./create-sandbox";
+import { resolveEnv } from "./env-resolver";
+import { gitCurrentBranch } from "./git";
+import { createWorktreeStrategy } from "./worktree-strategy";
+
+export async function createSandboxProgram(
+  options: CreateSandboxOptions<CreateSandboxProvider>,
+  seams: CreateSandboxSeams = {},
+): Promise<Sandbox> {
+  if (options.sandbox.kind !== "bind-mount") {
+    throw new Error(
+      `createSandbox() supports only bind-mount sandbox providers in this release; got ${options.sandbox.kind}.`,
+    );
+  }
+
+  const provider = options.sandbox;
+  const cwd = resolvePath(options.cwd ?? process.cwd());
+
+  const env = await resolveEnv({
+    processEnv: process.env,
+    sandduneEnvPath: join(cwd, ".sanddune", ".env"),
+    agentEnv: options.agent.env,
+    sandboxEnv: provider.env,
+    runOptionsEnv: options.env,
+  });
+
+  const targetBranch = await gitCurrentBranch(cwd);
+
+  // `branch: string` is the only knob — long-lived sandboxes are
+  // single-branch by construction, so there is no `branchStrategy`
+  // surface here (CONTEXT.md "createSandbox opts out of the branch
+  // strategy abstraction").
+  const strategy = await createWorktreeStrategy({
+    strategy: { type: "branch", branch: options.branch },
+    providerKind: provider.kind,
+    cwd,
+    hostBranch: targetBranch,
+  });
+
+  // On lifecycle failure, the helper closes any partial container and (because
+  // `ownsWorktree` is true here) unwinds the worktree before rethrowing.
+  return await createSandboxFromWorktree({
+    agent: options.agent,
+    provider,
+    hostRepoPath: cwd,
+    strategy,
+    env,
+    hooks: options.hooks,
+    copyToWorktree: options.copyToWorktree,
+    timeouts: options.timeouts,
+    logging: options.logging,
+    ownsWorktree: true,
+    seams,
+  });
+}

--- a/packages/sanddune/src/internal/create-sandbox.ts
+++ b/packages/sanddune/src/internal/create-sandbox.ts
@@ -1,0 +1,319 @@
+import { Effect, Layer } from "effect";
+import {
+  AgentInvoker,
+  preparePromptPipeline,
+  type AgentProvider,
+  type BindMountSandboxHandle,
+  type BindMountSandboxProvider,
+  type CloseResult,
+  type RunResult,
+  type Sandbox,
+  type SandboxHooks,
+  type SandboxInteractiveOptions,
+  type SandboxRunOptions,
+  type Timeouts,
+  type LoggingOption,
+} from "../core";
+import { NotImplementedError } from "../core";
+import { makeProductionAgentInvoker } from "./agent-invoker-live";
+import { runCopyToWorktree } from "./copy-to-worktree";
+import { gitHeadSha } from "./git";
+import {
+  runHostHooksSequential,
+  runOnSandboxReadyParallel,
+} from "./hook-runner";
+import { runIterationLoop, type IterationLoopResult } from "./iteration-loop";
+import { runEffect } from "./run-effect";
+import { openRunSession } from "./run-session";
+import { makeCaptureSessionFn } from "./session-capture";
+import type { WorktreeStrategy } from "./worktree-strategy";
+
+/** Set to 1 so existing single-iteration callers don't get a cost multiplier
+ *  — multi-iteration is opt-in via `maxIterations`. Mirrors run-program. */
+const DEFAULT_MAX_ITERATIONS = 1;
+const DEFAULT_COMPLETION_SIGNAL = "<promise>COMPLETE</promise>";
+const DEFAULT_IDLE_TIMEOUT_SECONDS = 600;
+
+export interface CreateSandboxFromWorktreeInput {
+  readonly agent: AgentProvider;
+  readonly provider: BindMountSandboxProvider;
+  readonly hostRepoPath: string;
+  readonly strategy: WorktreeStrategy;
+  /** Resolved env (per ADR-0012); already validated for agent/sandbox
+   *  overlap and merged with the caller's `createSandbox({ env })`. */
+  readonly env: Readonly<Record<string, string>>;
+  readonly hooks: SandboxHooks | undefined;
+  readonly copyToWorktree: readonly string[] | undefined;
+  readonly timeouts: Timeouts | undefined;
+  readonly logging: LoggingOption | undefined;
+  /** When `true`, `close()` tears down the worktree alongside the container.
+   *  Set by the top-level `createSandbox()` (ownership-follows-creation,
+   *  ADR-0010); `wt.createSandbox()` would pass `false` so the parent
+   *  `Worktree` retains worktree-teardown responsibility. */
+  readonly ownsWorktree: boolean;
+  readonly seams?: CreateSandboxSeams;
+}
+
+export interface CreateSandboxSeams {
+  /** Inject a fake `AgentInvoker` for tests — same seam as `runProgram`. */
+  readonly agentInvokerLayer?: Layer.Layer<AgentInvoker, never, never>;
+}
+
+/** Layered creator shared by top-level `createSandbox()` and (next slice)
+ *  `wt.createSandbox()`. Runs the lifecycle once at creation time:
+ *
+ *      copyToWorktree → host.onWorktreeReady → sandbox created →
+ *      host.onSandboxReady ∥ sandbox.onSandboxReady
+ *
+ *  After this returns, hooks do **not** re-fire on `sandbox.run()` — those
+ *  are inherited at construction per the brief.
+ *
+ *  Throws on lifecycle failure; on success returns a live `Sandbox` whose
+ *  `close()` is responsible for teardown (and, when `ownsWorktree`, the
+ *  worktree). */
+export async function createSandboxFromWorktree(
+  input: CreateSandboxFromWorktreeInput,
+): Promise<Sandbox> {
+  const { strategy, provider, agent, env } = input;
+
+  let handle: BindMountSandboxHandle | undefined;
+  try {
+    await runCopyToWorktree({
+      items: input.copyToWorktree,
+      cwd: input.hostRepoPath,
+      worktreePath: strategy.worktreePath,
+      branchStrategy: { type: "branch", branch: strategy.sourceBranch },
+      timeoutMs: input.timeouts?.copyToWorktreeMs,
+      signal: undefined,
+    });
+
+    await runHostHooksSequential(
+      input.hooks?.host?.onWorktreeReady,
+      undefined,
+    );
+
+    handle = await provider.create({
+      worktreePath: strategy.worktreePath,
+      hostRepoPath: input.hostRepoPath,
+      env,
+    });
+
+    await runOnSandboxReadyParallel({
+      hostHooks: input.hooks?.host?.onSandboxReady,
+      sandboxHooks: input.hooks?.sandbox?.onSandboxReady,
+      handle,
+      signal: undefined,
+    });
+  } catch (err) {
+    // Setup failed past worktree creation but possibly before the sandbox
+    // was ready — close any partial container, then unwind the worktree
+    // strategy if we own it. Each step swallows so the original error
+    // surfaces.
+    await closeHandleSafely(handle);
+    if (input.ownsWorktree) {
+      try {
+        await strategy.close();
+      } catch (closeErr) {
+        process.stderr.write(
+          `sanddune: worktree teardown failed: ${
+            closeErr instanceof Error ? closeErr.message : String(closeErr)
+          }\n`,
+        );
+      }
+    }
+    throw err;
+  }
+
+  return makeSandboxHandle({
+    agent,
+    handle: handle!,
+    strategy,
+    hostRepoPath: input.hostRepoPath,
+    baseEnv: env,
+    ownsWorktree: input.ownsWorktree,
+    creationLogging: input.logging,
+    seams: input.seams,
+  });
+}
+
+interface MakeSandboxHandleInput {
+  readonly agent: AgentProvider;
+  readonly handle: BindMountSandboxHandle;
+  readonly strategy: WorktreeStrategy;
+  readonly hostRepoPath: string;
+  readonly baseEnv: Readonly<Record<string, string>>;
+  readonly ownsWorktree: boolean;
+  /** Default `logging` configuration — per-`run()` `logging` overrides. */
+  readonly creationLogging: LoggingOption | undefined;
+  readonly seams?: CreateSandboxSeams;
+}
+
+function makeSandboxHandle(input: MakeSandboxHandleInput): Sandbox {
+  const { agent, handle, strategy } = input;
+  let closed = false;
+
+  const runOnce = async (
+    options: SandboxRunOptions,
+  ): Promise<RunResult> => {
+    if (closed) {
+      throw new Error("sandbox.run() called after close()");
+    }
+    // Belt-and-braces — type-level rejection prevents this in TS, but
+    // JS callers (or `as never` escapes) could still pass it. Per the
+    // brief ("rejected at type level on `SandboxRunOptions` and at runtime
+    // on `sandbox.run()`").
+    if ((options as { resumeSession?: unknown }).resumeSession !== undefined) {
+      throw new Error(
+        "sandbox.run() does not accept resumeSession — agent session resume is a fresh-sandbox concern (see CONTEXT.md).",
+      );
+    }
+
+    const maxIterations = options.maxIterations ?? DEFAULT_MAX_ITERATIONS;
+    const promptPipeline = await preparePromptPipeline({
+      prompt: options.prompt,
+      promptFile: options.promptFile,
+      promptArgs: options.promptArgs,
+      sourceBranch: strategy.sourceBranch,
+      targetBranch: strategy.targetBranch,
+    });
+    for (const key of promptPipeline.unusedPromptArgKeys) {
+      process.stderr.write(
+        `sanddune: warning — promptArgs.${key} was not used by the template\n`,
+      );
+    }
+
+    const logging = options.logging ?? input.creationLogging;
+    const session = await openRunSession({
+      cwd: input.hostRepoPath,
+      ...(logging !== undefined && { logging }),
+    });
+
+    const beforeSha = await gitHeadSha(strategy.worktreePath);
+
+    const agentInvokerLayer =
+      input.seams?.agentInvokerLayer ??
+      Layer.succeed(
+        AgentInvoker,
+        makeProductionAgentInvoker({
+          agentProvider: agent,
+          handle,
+        }),
+      );
+
+    const captureSession = makeCaptureSessionFn({
+      handle,
+      agent,
+      hostCwd: input.hostRepoPath,
+    });
+
+    let runError: Error | undefined;
+    let loopResult: IterationLoopResult | undefined;
+    try {
+      loopResult = await runEffect(
+        runIterationLoop({
+          getPromptForIteration: () =>
+            promptPipeline.getPromptForIteration((cmd) => handle.exec(cmd)),
+          logger: session.logger,
+          cwd: strategy.worktreePath,
+          beforeSha,
+          maxIterations,
+          completionSignals: normalizeCompletionSignals(
+            options.completionSignal,
+          ),
+          idleTimeoutSeconds:
+            options.idleTimeoutSeconds ?? DEFAULT_IDLE_TIMEOUT_SECONDS,
+          ...(options.signal !== undefined && { signal: options.signal }),
+          ...(captureSession !== undefined && { captureSession }),
+          onEvent: session.recordAgentEvent,
+        }).pipe(Effect.provide(agentInvokerLayer)),
+      );
+    } catch (err) {
+      runError = err instanceof Error ? err : new Error(String(err));
+    } finally {
+      await (runError !== undefined
+        ? session.endError(runError.message)
+        : session.endOk());
+    }
+
+    if (runError !== undefined) throw runError;
+    const r = loopResult!;
+
+    const result: RunResult = {
+      branch: strategy.resultBranch,
+      iterations: r.iterations,
+      commits: r.commits,
+      stdout: r.stdout,
+      ...(session.logFilePath !== undefined && {
+        logFilePath: session.logFilePath,
+      }),
+      ...(r.completionSignal !== undefined && {
+        completionSignal: r.completionSignal,
+      }),
+    };
+    return result;
+  };
+
+  const close = async (): Promise<CloseResult> => {
+    if (closed) return { worktreePreserved: false };
+    closed = true;
+
+    await closeHandleSafely(handle);
+
+    if (!input.ownsWorktree) {
+      // wt.createSandbox provenance: worktree teardown belongs to the
+      // parent Worktree, not us (ADR-0010 ownership-follows-creation).
+      return { worktreePreserved: false };
+    }
+
+    let preservedPath: string | undefined;
+    try {
+      const r = await strategy.close();
+      preservedPath = r.preservedPath;
+    } catch (e) {
+      process.stderr.write(
+        `sanddune: worktree teardown failed: ${
+          e instanceof Error ? e.message : String(e)
+        }\n`,
+      );
+    }
+    return preservedPath !== undefined
+      ? { worktreePreserved: true, preservedWorktreePath: preservedPath }
+      : { worktreePreserved: false };
+  };
+
+  return {
+    branch: strategy.resultBranch,
+    worktreePath: strategy.worktreePath,
+    run: runOnce,
+    interactive: async (_options: SandboxInteractiveOptions) => {
+      throw new NotImplementedError("Sandbox.interactive");
+    },
+    close,
+    [Symbol.asyncDispose]: async () => {
+      await close();
+    },
+  };
+}
+
+async function closeHandleSafely(
+  handle: BindMountSandboxHandle | undefined,
+): Promise<void> {
+  if (!handle) return;
+  try {
+    await handle.close();
+  } catch (closeError) {
+    process.stderr.write(
+      `sanddune: sandbox teardown failed: ${
+        closeError instanceof Error ? closeError.message : String(closeError)
+      }\n`,
+    );
+  }
+}
+
+function normalizeCompletionSignals(
+  raw: string | readonly string[] | undefined,
+): readonly string[] {
+  if (raw === undefined) return [DEFAULT_COMPLETION_SIGNAL];
+  if (typeof raw === "string") return [raw];
+  return raw;
+}

--- a/packages/sanddune/src/types.test.ts
+++ b/packages/sanddune/src/types.test.ts
@@ -10,6 +10,7 @@ import type {
   IsolatedSandboxProvider,
   NoSandboxProvider,
 } from "./core";
+import type { Sandbox } from "./core";
 import {
   createSandbox,
   createWorktree,
@@ -101,6 +102,11 @@ function _typeChecks() {
     prompt: "x",
     branchStrategy: { type: "branch", branch: "feat/x" },
   });
+
+  const sandboxStub = null as unknown as Sandbox;
+
+  // @ts-expect-error sandbox.run() rejects resumeSession at the type level
+  void sandboxStub.run({ prompt: "x", resumeSession: "abc" });
 }
 
 void _typeChecks;


### PR DESCRIPTION
Closes #16.

## Summary

- Top-level `createSandbox({ agent, sandbox, branch, ... })` returns a long-lived `Sandbox` handle. Multiple `sandbox.run()` calls accumulate commits on the same **branch** and reuse the same container — no restart cost between calls. Lifecycle **hooks** and `copyToWorktree` run once at creation time.
- `Sandbox` exposes `branch`, `worktreePath`, `run`, `interactive`, `close`, `[Symbol.asyncDispose]`. `await using sandbox = await createSandbox(...)` auto-disposes on block exit, including when an exception escapes.
- `SandboxRunOptions` rejects `resumeSession` at the type level (`resumeSession?: never`) and at runtime — Claude **agent session** chaining is a fresh-sandbox concern only.
- Per ADR-0010, the lifecycle is shared with the next slice (`wt.createSandbox()`) via an internal `createSandboxFromWorktree` helper. Top-level `createSandbox()` calls it with `ownsWorktree: true` so `close()` tears down both container and **worktree** (preserving the worktree on disk via `CloseResult.preservedWorktreePath` if dirty).
- `Sandbox.exec()` removed from the public surface (judgment call per the brief — `BindMountSandboxHandle.exec` is still available to internal code).

## Test plan

- [x] `bun test` — 214 pass, 1 skip, 0 fail. New `src/create-sandbox.integration.test.ts` adds 8 tests covering: create + 2 runs + close (commit accumulation, container reused), `await using` auto-dispose on success and on thrown exception, dirty preserved + clean removed, runtime `resumeSession` rejection, abort-then-rerun handle reuse, hooks fire once across multiple runs, idempotent close + run-after-close error.
- [x] `bun run typecheck` clean. `types.test.ts` adds a `@ts-expect-error` for `sandbox.run({ resumeSession })`.
- [ ] Smoke-test against a real Docker provider in a downstream consumer (out of CI scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)