### PR TITLE
feat: implement createWorktree() + wt.* + layered ownership

### DIFF
--- a/.changeset/create-worktree-lifecycle.md
+++ b/.changeset/create-worktree-lifecycle.md
@@ -1,0 +1,15 @@
+---
+"@missingstudio/sanddune": patch
+---
+
+Implemented `createWorktree()` — a **worktree** as a first-class lifecycle, separate from any **sandbox**. Returns a `Worktree` handle exposing `run()`, `interactive()`, `createSandbox()`, `close()`, and `[Symbol.asyncDispose]`. Useful for: run a session first and then hand the same worktree to a sandboxed AFK run, or layer multiple sandboxes on a single worktree.
+
+`createWorktree({ branchStrategy, cwd?, copyToWorktree?, timeouts? })` rejects `head` strategy at the type level (`NonHeadBranchStrategy`) and at runtime (defense in depth). `wt.run(options)` requires a `sandbox` and runs an AFK agent in the worktree — each call creates a fresh container, runs the iteration loop, calls `strategy.finalize()` on success (`merge-to-head` ff-merges back to host head; no-op for `branch`), then tears the container down. The worktree persists for subsequent calls. `wt.createSandbox(options)` returns a `Sandbox` whose `close()` tears down only the container — the worktree is owned by the parent `Worktree` and cleaned up by `wt.close()` (per ADR-0010 — layered sandbox creation, split-close).
+
+Top-level `createSandbox()` and `wt.createSandbox()` go through the same internal `createSandboxFromWorktree` helper and return the same `Sandbox` type. Bimodality is encoded in the close behavior — controlled by the `ownsWorktree` flag — not in distinct types (per ADR-0010 "Considered Options" #2 and #3).
+
+`wt.close()` checks `git status --porcelain` — dirty worktrees are preserved on disk and surfaced via `CloseResult.preservedWorktreePath`; clean worktrees are removed.
+
+`wt.interactive()` is wired at the type level (accepts any `InteractiveSandboxProvider` including bind-mount, isolated, and no-sandbox) but throws `NotImplementedError` at runtime — implementation is deferred to the next slice along with `noSandbox()` and the top-level `interactive()`.
+
+Public-type changes: `Worktree.path` renamed to `Worktree.worktreePath` (matches `Sandbox.worktreePath`); `Worktree.close()` now returns `Promise<CloseResult>`; `Worktree.branchStrategy` field now required on `CreateWorktreeOptions`. The previous shape was a stub that always threw — no caller depended on the prior signature.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ A TypeScript library for orchestrating AI coding agents in isolated sandboxes.
 | `IterationResult.usage`              | ✅ shipped | Raw token counts parsed from captured Claude session JSONL (per ADR-0005b)       |
 | Custom bind-mount provider           | ✅ shipped | Build your own by constructing a `BindMountSandboxProvider` |
 | `createSandbox()`                   | ✅ shipped | Long-lived reusable sandbox on a single branch; multiple `sandbox.run()` calls reuse the container; `await using` auto-disposes |
+| `createWorktree()`                  | ✅ shipped | Long-lived worktree as an independent lifecycle; `wt.run()` / `wt.createSandbox()` layer on top with split-close ownership (ADR-0010); `wt.interactive()` deferred to a later release |
 
 ## Quick start
 

--- a/packages/sanddune/src/core/worktree.ts
+++ b/packages/sanddune/src/core/worktree.ts
@@ -10,11 +10,13 @@ import type {
 } from "./sandbox-provider";
 import type { Timeouts } from "./timeouts";
 import type { RunResult } from "./run";
-import type { Sandbox } from "./sandbox";
+import type { CloseResult, Sandbox } from "./sandbox";
 
 export interface CreateWorktreeOptions {
+  readonly branchStrategy: NonHeadBranchStrategy;
   readonly cwd?: string;
-  readonly branchStrategy?: NonHeadBranchStrategy;
+  readonly copyToWorktree?: readonly string[];
+  readonly timeouts?: Timeouts;
 }
 
 export type WorktreeRunOptions<
@@ -57,11 +59,16 @@ export interface WorktreeCreateSandboxOptions<
 }
 
 export interface Worktree {
-  readonly path: string;
+  readonly worktreePath: string;
   readonly branch: string;
   readonly branchStrategy: NonHeadBranchStrategy;
   run(options: WorktreeRunOptions): Promise<RunResult>;
   interactive(options: WorktreeInteractiveOptions): Promise<void>;
   createSandbox(options: WorktreeCreateSandboxOptions): Promise<Sandbox>;
-  close(): Promise<void>;
+  /** Tears down only the worktree (ADR-0010 — sandboxes spawned via
+   *  `wt.createSandbox()` must be closed by the caller first). Dirty
+   *  worktrees are preserved on disk and surfaced via
+   *  `CloseResult.preservedWorktreePath`. */
+  close(): Promise<CloseResult>;
+  [Symbol.asyncDispose](): Promise<void>;
 }

--- a/packages/sanddune/src/create-worktree.integration.test.ts
+++ b/packages/sanddune/src/create-worktree.integration.test.ts
@@ -1,0 +1,408 @@
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { Effect, Layer } from "effect";
+import {
+  AgentInvoker,
+  NotImplementedError,
+  type AgentInvokerService,
+  type AgentProvider,
+  type BindMountSandboxHandle,
+  type BindMountSandboxProvider,
+} from "./core";
+import { createWorktreeProgram } from "./internal/create-worktree-program";
+
+describe("createWorktree (integration)", () => {
+  let repo: string;
+
+  beforeEach(async () => {
+    repo = await mkdtemp(join(tmpdir(), "sanddune-cw-"));
+    runSync("git", ["init", "--initial-branch=main"], repo);
+    runSync("git", ["config", "user.email", "test@example.com"], repo);
+    runSync("git", ["config", "user.name", "test"], repo);
+    runSync("git", ["config", "commit.gpgsign", "false"], repo);
+    await writeFile(join(repo, "README.md"), "seed\n");
+    runSync("git", ["add", "."], repo);
+    runSync("git", ["commit", "-m", "seed"], repo);
+  });
+
+  afterEach(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  test("worktree exposes branch + worktreePath; close() removes a clean worktree", async () => {
+    const wt = await createWorktreeProgram({
+      branchStrategy: { type: "branch", branch: "agent/clean" },
+      cwd: repo,
+    });
+
+    expect(wt.branch).toBe("agent/clean");
+    expect(wt.worktreePath).toBe(
+      join(repo, ".sanddune", "worktrees", "agent-clean"),
+    );
+    expect(existsSync(wt.worktreePath)).toBe(true);
+
+    const close = await wt.close();
+    expect(close.worktreePreserved).toBe(false);
+    expect(close.preservedWorktreePath).toBeUndefined();
+    expect(existsSync(wt.worktreePath)).toBe(false);
+  });
+
+  test("rejects head branchStrategy at runtime (defense in depth past the type-level guard)", async () => {
+    await expect(
+      createWorktreeProgram({
+        // Cast through unknown — the type forbids this, but JS callers can.
+        branchStrategy: { type: "head" } as unknown as Parameters<
+          typeof createWorktreeProgram
+        >[0]["branchStrategy"],
+        cwd: repo,
+      }),
+    ).rejects.toThrow(/branchStrategy "head"/);
+  });
+
+  test("wt.run() commits land on the worktree's branch and survive close", async () => {
+    const closeCalls: number[] = [];
+    const provider = makeBindMountProvider({ closeCalls });
+    const agent: AgentProvider = {
+      name: "stub",
+      buildCommand: () => "true",
+      parseLine: () => [],
+    };
+
+    const handleRef: { current: BindMountSandboxHandle | undefined } = {
+      current: undefined,
+    };
+    const fakeInvoker = scriptedAgent(handleRef, [
+      "printf 'one\\n' > a.txt && git add a.txt && git -c user.email=agent@example.com -c user.name=agent -c commit.gpgsign=false commit -m 'first'",
+    ]);
+
+    const wt = await createWorktreeProgram(
+      {
+        branchStrategy: { type: "branch", branch: "agent/wtrun" },
+        cwd: repo,
+      },
+      {
+        sandboxSeams: {
+          agentInvokerLayer: Layer.succeed(AgentInvoker, fakeInvoker.invoker),
+        },
+      },
+    );
+
+    const r = await wt.run({
+      agent,
+      sandbox: capturing(provider, handleRef),
+      prompt: "do A",
+    });
+    expect(r.commits).toHaveLength(1);
+    expect(r.branch).toBe("agent/wtrun");
+    // wt.run() owns the container only — it must close after the run.
+    expect(closeCalls).toEqual([1]);
+
+    const branchLog = runSync(
+      "git",
+      ["log", "agent/wtrun", "--format=%s"],
+      repo,
+    ).stdout;
+    expect(branchLog).toContain("first");
+
+    // Worktree still exists after wt.run() — only the container was torn
+    // down. Caller is responsible for wt.close().
+    expect(existsSync(wt.worktreePath)).toBe(true);
+
+    const close = await wt.close();
+    expect(close.worktreePreserved).toBe(false);
+    expect(existsSync(wt.worktreePath)).toBe(false);
+  });
+
+  test("wt.createSandbox() ownership: sandbox.close keeps worktree, wt.close removes it (ADR-0010)", async () => {
+    const closeCalls: number[] = [];
+    const createCalls: number[] = [];
+    const provider = makeBindMountProvider({ closeCalls, createCalls });
+    const agent: AgentProvider = {
+      name: "stub",
+      buildCommand: () => "true",
+      parseLine: () => [],
+    };
+
+    const handleRef: { current: BindMountSandboxHandle | undefined } = {
+      current: undefined,
+    };
+    const fakeInvoker = scriptedAgent(handleRef, [
+      "printf 'a\\n' > a.txt && git add a.txt && git -c user.email=agent@example.com -c user.name=agent -c commit.gpgsign=false commit -m 'a'",
+    ]);
+
+    const wt = await createWorktreeProgram(
+      {
+        branchStrategy: { type: "branch", branch: "agent/owned" },
+        cwd: repo,
+      },
+      {
+        sandboxSeams: {
+          agentInvokerLayer: Layer.succeed(AgentInvoker, fakeInvoker.invoker),
+        },
+      },
+    );
+
+    const sandbox = await wt.createSandbox({
+      agent,
+      sandbox: capturing(provider, handleRef),
+    });
+    expect(createCalls).toEqual([1]);
+
+    await sandbox.run({ prompt: "go" });
+
+    const sandboxClose = await sandbox.close();
+    // wt-owned worktree → sandbox.close() must NOT report preservation,
+    // and the worktree must still exist on disk for the parent Worktree
+    // to clean up (ADR-0010 ownership-follows-creation).
+    expect(sandboxClose.worktreePreserved).toBe(false);
+    expect(sandboxClose.preservedWorktreePath).toBeUndefined();
+    expect(closeCalls).toEqual([1]);
+    expect(existsSync(wt.worktreePath)).toBe(true);
+
+    const wtClose = await wt.close();
+    expect(wtClose.worktreePreserved).toBe(false);
+    expect(existsSync(wt.worktreePath)).toBe(false);
+  });
+
+  test("wt.close() preserves a dirty worktree and surfaces preservedWorktreePath", async () => {
+    const closeCalls: number[] = [];
+    const provider = makeBindMountProvider({ closeCalls });
+    const agent: AgentProvider = {
+      name: "stub",
+      buildCommand: () => "true",
+      parseLine: () => [],
+    };
+
+    const handleRef: { current: BindMountSandboxHandle | undefined } = {
+      current: undefined,
+    };
+    const dirtyInvoker = scriptedAgent(handleRef, [
+      "printf 'committed\\n' > committed.txt && git add committed.txt && git -c user.email=agent@example.com -c user.name=agent -c commit.gpgsign=false commit -m 'committed' && printf 'leftover\\n' > leftover.txt",
+    ]);
+
+    const wt = await createWorktreeProgram(
+      {
+        branchStrategy: { type: "branch", branch: "agent/dirty-wt" },
+        cwd: repo,
+      },
+      {
+        sandboxSeams: {
+          agentInvokerLayer: Layer.succeed(AgentInvoker, dirtyInvoker.invoker),
+        },
+      },
+    );
+
+    await wt.run({
+      agent,
+      sandbox: capturing(provider, handleRef),
+      prompt: "leave a mess",
+    });
+
+    const close = await wt.close();
+    expect(close.worktreePreserved).toBe(true);
+    expect(close.preservedWorktreePath).toBe(wt.worktreePath);
+    expect(existsSync(wt.worktreePath)).toBe(true);
+    expect(existsSync(join(wt.worktreePath, "leftover.txt"))).toBe(true);
+  });
+
+  test("wt.interactive() throws NotImplementedError until #18 lands", async () => {
+    const wt = await createWorktreeProgram({
+      branchStrategy: { type: "branch", branch: "agent/tui" },
+      cwd: repo,
+    });
+    try {
+      const provider = makeBindMountProvider({ closeCalls: [] });
+      const agent: AgentProvider = {
+        name: "stub",
+        buildCommand: () => "true",
+        parseLine: () => [],
+      };
+      await expect(
+        wt.interactive({ agent, sandbox: provider, prompt: "x" }),
+      ).rejects.toThrow(NotImplementedError);
+    } finally {
+      await wt.close();
+    }
+  });
+
+  test("await using auto-disposes the worktree on block exit", async () => {
+    const branch = "agent/auto-wt";
+    const path = join(repo, ".sanddune", "worktrees", "agent-auto-wt");
+    {
+      await using wt = await createWorktreeProgram({
+        branchStrategy: { type: "branch", branch },
+        cwd: repo,
+      });
+      expect(wt.worktreePath).toBe(path);
+      expect(existsSync(path)).toBe(true);
+    }
+    expect(existsSync(path)).toBe(false);
+  });
+
+  test("wt.close() is idempotent and locks out further operations", async () => {
+    const wt = await createWorktreeProgram({
+      branchStrategy: { type: "branch", branch: "agent/idem-wt" },
+      cwd: repo,
+    });
+    await wt.close();
+    const second = await wt.close();
+    expect(second.worktreePreserved).toBe(false);
+
+    const provider = makeBindMountProvider({ closeCalls: [] });
+    const agent: AgentProvider = {
+      name: "stub",
+      buildCommand: () => "true",
+      parseLine: () => [],
+    };
+    await expect(
+      wt.run({ agent, sandbox: provider, prompt: "x" }),
+    ).rejects.toThrow(/closed/);
+  });
+
+  test("merge-to-head: wt.run() finalizes the temp branch back into host head", async () => {
+    const closeCalls: number[] = [];
+    const provider = makeBindMountProvider({ closeCalls });
+    const agent: AgentProvider = {
+      name: "stub",
+      buildCommand: () => "true",
+      parseLine: () => [],
+    };
+
+    const handleRef: { current: BindMountSandboxHandle | undefined } = {
+      current: undefined,
+    };
+    const fakeInvoker = scriptedAgent(handleRef, [
+      "printf 'mth\\n' > mth.txt && git add mth.txt && git -c user.email=agent@example.com -c user.name=agent -c commit.gpgsign=false commit -m 'mth-commit'",
+    ]);
+
+    const wt = await createWorktreeProgram(
+      {
+        branchStrategy: { type: "merge-to-head" },
+        cwd: repo,
+      },
+      {
+        sandboxSeams: {
+          agentInvokerLayer: Layer.succeed(AgentInvoker, fakeInvoker.invoker),
+        },
+      },
+    );
+
+    const r = await wt.run({
+      agent,
+      sandbox: capturing(provider, handleRef),
+      prompt: "go",
+    });
+    expect(r.branch).toBe("main");
+    // The host head should now contain the agent's commit (finalize ff-merged).
+    const hostLog = runSync(
+      "git",
+      ["log", "main", "--format=%s"],
+      repo,
+    ).stdout;
+    expect(hostLog).toContain("mth-commit");
+
+    const close = await wt.close();
+    expect(close.worktreePreserved).toBe(false);
+  });
+});
+
+function makeBindMountProvider(input: {
+  readonly closeCalls: number[];
+  readonly createCalls?: number[];
+}): BindMountSandboxProvider {
+  const { closeCalls, createCalls } = input;
+  return {
+    kind: "bind-mount",
+    name: "local-process",
+    create: async ({ worktreePath }) => {
+      createCalls?.push(1);
+      return {
+        worktreePath,
+        exec: async (command, opts) => {
+          const result = spawnSync("sh", ["-c", command], {
+            cwd: opts?.cwd ?? worktreePath,
+            encoding: "utf8",
+          });
+          return {
+            stdout: result.stdout ?? "",
+            stderr: result.stderr ?? "",
+            exitCode: result.status ?? 0,
+          };
+        },
+        close: async () => {
+          closeCalls.push(1);
+        },
+      };
+    },
+  };
+}
+
+function capturing(
+  inner: BindMountSandboxProvider,
+  handleRef: { current: BindMountSandboxHandle | undefined },
+): BindMountSandboxProvider {
+  return {
+    kind: "bind-mount",
+    name: inner.name,
+    create: async (options) => {
+      const handle = await inner.create(options);
+      handleRef.current = handle;
+      return handle;
+    },
+  };
+}
+
+function scriptedAgent(
+  handleRef: { current: BindMountSandboxHandle | undefined },
+  scripts: readonly string[],
+): { invoker: AgentInvokerService } {
+  let i = 0;
+  return {
+    invoker: {
+      invoke: ({ iteration }) =>
+        Effect.tryPromise({
+          try: async () => {
+            const handle = handleRef.current;
+            if (!handle) throw new Error("handle not yet captured");
+            const script = scripts[i];
+            i += 1;
+            if (script === undefined) {
+              throw new Error(
+                `no scripted command for invocation ${i} (iteration ${iteration})`,
+              );
+            }
+            await handle.exec(script);
+            return {
+              events: [
+                {
+                  type: "text" as const,
+                  content: `iteration ${iteration} done\n`,
+                  iteration,
+                  timestamp: Date.now(),
+                },
+              ],
+            };
+          },
+          catch: (e) => (e instanceof Error ? e : new Error(String(e))),
+        }),
+    },
+  };
+}
+
+function runSync(
+  cmd: string,
+  args: readonly string[],
+  cwd: string,
+): { stdout: string; stderr: string } {
+  const r = spawnSync(cmd, args, { cwd, encoding: "utf8" });
+  if (r.status !== 0) {
+    throw new Error(
+      `${cmd} ${args.join(" ")} failed: ${r.stderr ?? ""}${r.stdout ?? ""}`,
+    );
+  }
+  return { stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}

--- a/packages/sanddune/src/index.test.ts
+++ b/packages/sanddune/src/index.test.ts
@@ -1,19 +1,12 @@
 import { describe, expect, test } from "bun:test";
 import { NotImplementedError } from "./core";
-import { createWorktree, interactive } from "./index";
+import { interactive } from "./index";
 import { docker } from "./sandboxes/docker";
 import { noSandbox } from "./sandboxes/no-sandbox";
 import { podman } from "./sandboxes/podman";
 import { vercel } from "./sandboxes/vercel";
 
 describe("entry-point stubs throw NotImplementedError", () => {
-  test("createWorktree", () => {
-    expect(() => createWorktree()).toThrow(NotImplementedError);
-    expect(() => createWorktree()).toThrow(
-      /^createWorktree is not implemented$/,
-    );
-  });
-
   test("interactive", () => {
     expect(() => interactive({} as never)).toThrow(NotImplementedError);
     expect(() => interactive({} as never)).toThrow(

--- a/packages/sanddune/src/index.ts
+++ b/packages/sanddune/src/index.ts
@@ -12,6 +12,7 @@ import type {
   Worktree,
 } from "./core";
 import { createSandboxProgram } from "./internal/create-sandbox-program";
+import { createWorktreeProgram } from "./internal/create-worktree-program";
 import { runProgram } from "./internal/run-program";
 
 export * from "./core";
@@ -32,9 +33,9 @@ export function createSandbox<S extends CreateSandboxProvider>(
 }
 
 export function createWorktree(
-  _options?: CreateWorktreeOptions,
+  options: CreateWorktreeOptions,
 ): Promise<Worktree> {
-  throw new NotImplementedError("createWorktree");
+  return createWorktreeProgram(options);
 }
 
 export function interactive<S extends InteractiveSandboxProvider>(

--- a/packages/sanddune/src/internal/create-worktree-program.ts
+++ b/packages/sanddune/src/internal/create-worktree-program.ts
@@ -1,0 +1,223 @@
+import { resolve as resolvePath } from "node:path";
+import {
+  type CloseResult,
+  type CreateWorktreeOptions,
+  type RunResult,
+  type Sandbox,
+  type Worktree,
+  type WorktreeCreateSandboxOptions,
+  type WorktreeInteractiveOptions,
+  type WorktreeRunOptions,
+} from "../core";
+import { NotImplementedError } from "../core";
+import {
+  createSandboxFromWorktree,
+  type CreateSandboxSeams,
+} from "./create-sandbox";
+import { resolveEnv } from "./env-resolver";
+import { gitCurrentBranch } from "./git";
+import { join } from "node:path";
+import { createWorktreeStrategy, type WorktreeStrategy } from "./worktree-strategy";
+
+export interface CreateWorktreeSeams {
+  readonly sandboxSeams?: CreateSandboxSeams;
+}
+
+/** Builds a long-lived `Worktree` handle. The worktree is created here and
+ *  torn down only by `wt.close()` (ADR-0010); sandboxes layered via
+ *  `wt.createSandbox()` close their containers without touching the worktree. */
+export async function createWorktreeProgram(
+  options: CreateWorktreeOptions,
+  seams: CreateWorktreeSeams = {},
+): Promise<Worktree> {
+  // Belt-and-braces — `NonHeadBranchStrategy` already excludes `head` at the
+  // type level, but JS callers (or `as never` escapes) could still pass it.
+  if ((options.branchStrategy as { type: string }).type === "head") {
+    throw new Error(
+      `createWorktree() does not accept branchStrategy "head" — long-lived worktrees must be either { type: "branch", branch } or { type: "merge-to-head" }.`,
+    );
+  }
+
+  const cwd = resolvePath(options.cwd ?? process.cwd());
+  const hostBranch = await gitCurrentBranch(cwd);
+
+  // `providerKind` is only used by `createWorktreeStrategy` to reject
+  // `head + isolated`. Since we've already rejected `head`, the provider
+  // kind is irrelevant — pass `bind-mount` as a placeholder that satisfies
+  // the strategy's validation.
+  const strategy = await createWorktreeStrategy({
+    strategy: options.branchStrategy,
+    providerKind: "bind-mount",
+    cwd,
+    hostBranch,
+  });
+
+  return makeWorktreeHandle({
+    strategy,
+    hostRepoPath: cwd,
+    branchStrategy: options.branchStrategy,
+    creationCopyToWorktree: options.copyToWorktree,
+    creationTimeouts: options.timeouts,
+    sandboxSeams: seams.sandboxSeams,
+  });
+}
+
+interface MakeWorktreeHandleInput {
+  readonly strategy: WorktreeStrategy;
+  readonly hostRepoPath: string;
+  readonly branchStrategy: CreateWorktreeOptions["branchStrategy"];
+  readonly creationCopyToWorktree: readonly string[] | undefined;
+  readonly creationTimeouts: CreateWorktreeOptions["timeouts"];
+  readonly sandboxSeams: CreateSandboxSeams | undefined;
+}
+
+function makeWorktreeHandle(input: MakeWorktreeHandleInput): Worktree {
+  const { strategy, hostRepoPath } = input;
+  let closed = false;
+
+  const ensureOpen = (): void => {
+    if (closed) throw new Error("worktree is closed");
+  };
+
+  const wtRun = async (options: WorktreeRunOptions): Promise<RunResult> => {
+    ensureOpen();
+    if (options.sandbox.kind !== "bind-mount") {
+      throw new Error(
+        `wt.run() supports only bind-mount sandbox providers in this release; got ${options.sandbox.kind}.`,
+      );
+    }
+    const provider = options.sandbox;
+
+    const env = await resolveEnv({
+      processEnv: process.env,
+      sandduneEnvPath: join(hostRepoPath, ".sanddune", ".env"),
+      agentEnv: options.agent.env,
+      sandboxEnv: provider.env,
+      runOptionsEnv: options.env,
+    });
+
+    // Each `wt.run()` is a complete AFK run — fire creation hooks, run the
+    // iteration loop, finalize on success, then tear down only the container
+    // (worktree stays for the next `wt.run()` / `wt.createSandbox()` /
+    // `wt.close()`). `ownsWorktree: false` is the ADR-0010 pivot.
+    const sandbox = await createSandboxFromWorktree({
+      agent: options.agent,
+      provider,
+      hostRepoPath,
+      strategy,
+      env,
+      hooks: options.hooks,
+      copyToWorktree: options.copyToWorktree ?? input.creationCopyToWorktree,
+      timeouts: options.timeouts ?? input.creationTimeouts,
+      logging: options.logging,
+      ownsWorktree: false,
+      ...(input.sandboxSeams !== undefined && { seams: input.sandboxSeams }),
+    });
+
+    let result: RunResult;
+    try {
+      result = await sandbox.run({
+        ...(options.prompt !== undefined && { prompt: options.prompt }),
+        ...(options.promptFile !== undefined && {
+          promptFile: options.promptFile,
+        }),
+        ...(options.promptArgs !== undefined && {
+          promptArgs: options.promptArgs,
+        }),
+        ...(options.maxIterations !== undefined && {
+          maxIterations: options.maxIterations,
+        }),
+        ...(options.completionSignal !== undefined && {
+          completionSignal: options.completionSignal,
+        }),
+        ...(options.idleTimeoutSeconds !== undefined && {
+          idleTimeoutSeconds: options.idleTimeoutSeconds,
+        }),
+        ...(options.signal !== undefined && { signal: options.signal }),
+        ...(options.logging !== undefined && { logging: options.logging }),
+      } as Parameters<typeof sandbox.run>[0]);
+      // `merge-to-head`: ff-merge the temp branch back into host head; no-op
+      // for `branch`. Only runs on a successful iteration loop — matches
+      // `runProgram()` semantics.
+      await strategy.finalize();
+    } finally {
+      // Closes the container only — `ownsWorktree: false` keeps the
+      // worktree under the parent `Worktree`'s ownership.
+      await sandbox.close();
+    }
+    return result;
+  };
+
+  const wtInteractive = async (
+    _options: WorktreeInteractiveOptions,
+  ): Promise<void> => {
+    ensureOpen();
+    // Deferred to #18 (Interactive + noSandbox). Type-level acceptance of
+    // all three sandbox kinds is already in `WorktreeInteractiveOptions`.
+    throw new NotImplementedError("Worktree.interactive");
+  };
+
+  const wtCreateSandbox = async (
+    options: WorktreeCreateSandboxOptions,
+  ): Promise<Sandbox> => {
+    ensureOpen();
+    if (options.sandbox.kind !== "bind-mount") {
+      throw new Error(
+        `wt.createSandbox() supports only bind-mount sandbox providers in this release; got ${options.sandbox.kind}.`,
+      );
+    }
+    const provider = options.sandbox;
+    const env = await resolveEnv({
+      processEnv: process.env,
+      sandduneEnvPath: join(hostRepoPath, ".sanddune", ".env"),
+      agentEnv: options.agent.env,
+      sandboxEnv: provider.env,
+      runOptionsEnv: options.env,
+    });
+    return await createSandboxFromWorktree({
+      agent: options.agent,
+      provider,
+      hostRepoPath,
+      strategy,
+      env,
+      hooks: options.hooks,
+      copyToWorktree: options.copyToWorktree ?? input.creationCopyToWorktree,
+      timeouts: options.timeouts ?? input.creationTimeouts,
+      logging: options.logging,
+      ownsWorktree: false,
+      ...(input.sandboxSeams !== undefined && { seams: input.sandboxSeams }),
+    });
+  };
+
+  const close = async (): Promise<CloseResult> => {
+    if (closed) return { worktreePreserved: false };
+    closed = true;
+    let preservedPath: string | undefined;
+    try {
+      const r = await strategy.close();
+      preservedPath = r.preservedPath;
+    } catch (e) {
+      process.stderr.write(
+        `sanddune: worktree teardown failed: ${
+          e instanceof Error ? e.message : String(e)
+        }\n`,
+      );
+    }
+    return preservedPath !== undefined
+      ? { worktreePreserved: true, preservedWorktreePath: preservedPath }
+      : { worktreePreserved: false };
+  };
+
+  return {
+    worktreePath: strategy.worktreePath,
+    branch: strategy.resultBranch,
+    branchStrategy: input.branchStrategy,
+    run: wtRun,
+    interactive: wtInteractive,
+    createSandbox: wtCreateSandbox,
+    close,
+    [Symbol.asyncDispose]: async () => {
+      await close();
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Implements `createWorktree()` (closes #17): worktree as a first-class lifecycle with `run()`, `interactive()`, `createSandbox()`, `close()`, and `[Symbol.asyncDispose]`. Long-lived worktree, layered sandboxes via `wt.createSandbox()`, split-close ownership per ADR-0010.
- `wt.run()` reuses the existing `createSandboxFromWorktree` helper with `ownsWorktree: false` — fresh container per call, finalizes on success (`merge-to-head` ff-merges back; `branch` is a no-op), tears down container only.
- `wt.close()` checks `git status --porcelain`: dirty → preserved + `CloseResult.preservedWorktreePath`; clean → removed.
- `branchStrategy: { type: \"head\" }` rejected at the type level (`NonHeadBranchStrategy`) and at runtime (defense in depth).
- `wt.interactive()` types accept any `InteractiveSandboxProvider` (bind-mount, isolated, no-sandbox) but throws `NotImplementedError` until #18 lands `noSandbox()` and the default — explicit ordering rule from the agent brief.

## Public-type changes (previously-stubbed `Worktree`)

- `path` → `worktreePath` (matches `Sandbox`)
- `close()` returns `Promise<CloseResult>`
- `branchStrategy` required on `CreateWorktreeOptions`

The prior shape always threw, so no caller depended on it.

## Test plan

- [x] \`bun run typecheck\` passes
- [x] \`bun test\` passes (223 / 1 skip / 0 fail; +9 new tests in \`create-worktree.integration.test.ts\`)
- [x] Test coverage: clean-close, dirty-preservation with \`preservedWorktreePath\`, runtime \`head\` rejection, \`wt.run()\` commits + container-only close, \`wt.createSandbox()\` ownership (sandbox.close keeps worktree, wt.close removes), \`wt.interactive()\` throws \`NotImplementedError\`, \`await using\` auto-dispose, idempotent close, \`merge-to-head\` finalize ff-merges back to host head
- [x] Changeset added (\`.changeset/create-worktree-lifecycle.md\`, patch)
- [x] README status table updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)