### PR TITLE
feat: implement interactive() + noSandbox + wt.interactive()

### DIFF
--- a/.changeset/interactive-and-no-sandbox.md
+++ b/.changeset/interactive-and-no-sandbox.md
@@ -1,0 +1,17 @@
+---
+"@missingstudio/sanddune": patch
+---
+
+Implement `interactive()`, `wt.interactive()`, and the `noSandbox()` **sandbox provider** — the TUI side of the API.
+
+`interactive()` launches an **agent**'s interactive UI inside a **sandbox** or directly on the **host** and resolves when the user exits the TUI. Accepts all three sandbox provider kinds (**bind-mount**, **isolated**, **no-sandbox**); always uses the provider's default **branch strategy** (no `branchStrategy` option — route through `createWorktree() + wt.interactive()` for non-default strategies, per ADR-0009). Honors `cwd` for cross-repo TUI sessions, `signal` for cancellable launch, `prompt` / `promptFile` / `promptArgs` for an optional seed prompt, and the standard `hooks` / `env` / `copyToWorktree` lifecycle. No `maxIterations` or `completionSignal` — interactive sessions are user-driven.
+
+`noSandbox()` runs the **agent** directly on the **host** with no container. Accepted only by `interactive()` / `wt.interactive()`; the type system still rejects it for `run()` and `createSandbox()`. With **no-sandbox**, sanddune does **not** pass `--dangerously-skip-permissions` to the **agent provider** so the agent's normal permission prompts stay active. Bind-mount and isolated providers in interactive mode still receive the flag.
+
+`wt.interactive()` accepts any **sandbox provider** and defaults to `noSandbox()` when none is supplied. The parent `Worktree` keeps ownership of the **worktree** for the duration of the TUI and across it (per ADR-0010 "ownership follows creation").
+
+The **agent provider** interface gains an optional `buildInteractiveCommand(input)` capability used by `interactive()`. Agent providers without it are rejected at runtime when `interactive()` is invoked. The `claudeCode()` provider implements it: emits `claude --model <m>` plus `--dangerously-skip-permissions` only when `skipPermissions: true`. AFK `buildCommand` behavior is unchanged.
+
+`BindMountSandboxHandle` gains an optional `execInteractive(command, { cwd?, signal? })` method for stdio-inherited subprocess launches; the `docker()` provider implements it via `docker exec -it`.
+
+Out of scope of this slice: real `vercel()` / isolated-provider runtime (the type is accepted by `interactive()` but the orchestrator rejects it at runtime), `Sandbox.interactive()` on long-lived sandboxes, and `resumeSession` plumbing for interactive TUIs.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,9 @@ A TypeScript library for orchestrating AI coding agents in isolated sandboxes.
 | `IterationResult.usage`              | ✅ shipped | Raw token counts parsed from captured Claude session JSONL (per ADR-0005b)       |
 | Custom bind-mount provider           | ✅ shipped | Build your own by constructing a `BindMountSandboxProvider` |
 | `createSandbox()`                   | ✅ shipped | Long-lived reusable sandbox on a single branch; multiple `sandbox.run()` calls reuse the container; `await using` auto-disposes |
-| `createWorktree()`                  | ✅ shipped | Long-lived worktree as an independent lifecycle; `wt.run()` / `wt.createSandbox()` layer on top with split-close ownership (ADR-0010); `wt.interactive()` deferred to a later release |
+| `createWorktree()`                  | ✅ shipped | Long-lived worktree as an independent lifecycle; `wt.run()` / `wt.createSandbox()` / `wt.interactive()` layer on top with split-close ownership (ADR-0010) |
+| `interactive()`                     | ✅ shipped | Launches the agent's TUI inside a sandbox or directly on the host; accepts `bind-mount`, `isolated`, or `no-sandbox` providers; uses the provider's default branch strategy |
+| `noSandbox()` sandbox provider      | ✅ shipped | Runs the agent on the host with no container; accepted only by `interactive()` / `wt.interactive()`; the agent's normal permission prompts stay active |
 
 ## Quick start
 
@@ -299,6 +301,58 @@ claudeCode("claude-opus-4-7", {
 ```
 
 `captureSessions` controls whether each iteration's **agent session** JSONL is captured from the sandbox to the host (`~/.claude/projects/<encoded-cwd>/sessions/<id>.jsonl`, with `cwd` rewritten so `claude --resume` works natively). Capture is best-effort — failure logs a warning and the run still resolves successfully. The `effort` option shown in the brief doesn't exist yet.
+
+### `interactive(options)` and `wt.interactive(options)`
+
+`interactive()` launches the **agent**'s interactive UI (e.g. Claude Code's TUI) and resolves when the user exits. It accepts all three sandbox provider kinds — **bind-mount**, **isolated**, and **no-sandbox** — and always uses the provider's default **branch strategy**. There is no `branchStrategy` option on top-level `interactive()`; for a non-default strategy with a TUI, route through `createWorktree() + wt.interactive()` (per [ADR-0009](docs/adr/0009-branch-strategy-per-call.md)).
+
+```typescript
+import { createWorktree, interactive, claudeCode } from "@missingstudio/sanddune";
+import { docker } from "@missingstudio/sanddune/sandboxes/docker";
+import { noSandbox } from "@missingstudio/sanddune/sandboxes/no-sandbox";
+
+// TUI inside Docker — same flow as run(), but you drive it.
+await interactive({
+  agent: claudeCode("claude-opus-4-7"),
+  sandbox: docker(),
+  prompt: "Help me refactor the prompt pipeline.",  // optional seed prompt
+});
+
+// TUI directly on the host — no container, agent's permission prompts stay on.
+await interactive({
+  agent: claudeCode("claude-opus-4-7"),
+  sandbox: noSandbox(),
+  cwd: "../other-repo",   // optional; relative paths resolve against process.cwd()
+});
+
+// TUI on a worktree branch (non-default strategy needs the wt.* path).
+await using wt = await createWorktree({
+  branchStrategy: { type: "branch", branch: "agent/explore" },
+});
+await wt.interactive({ agent: claudeCode("claude-opus-4-7") });
+// `sandbox` defaults to noSandbox() on wt.interactive(); pass docker() etc. to override.
+```
+
+| Option            | Type                            | Behavior                                                            |
+| ----------------- | ------------------------------- | ------------------------------------------------------------------- |
+| `agent`           | `AgentProvider`                 | **Required.** Must declare `buildInteractiveCommand` (claudeCode does) |
+| `sandbox`         | `InteractiveSandboxProvider`    | **Required** on `interactive()`; defaults to `noSandbox()` on `wt.interactive()` |
+| `prompt`          | `string`                        | Optional seed prompt; passed as a positional arg to the agent       |
+| `promptFile`      | `string`                        | Optional template file; `{{KEY}}` substitution + shell expressions  |
+| `promptArgs`      | `Record<string, string\|number>`  | Values for `{{KEY}}` placeholders; only valid with `promptFile`     |
+| `cwd`             | `string`                        | Host repo dir; relative paths resolve from `process.cwd()`          |
+| `env`             | `Record<string, string>`        | Call-site env override (per ADR-0012)                               |
+| `hooks`           | `SandboxHooks`                  | Same shape as `run()`; sandbox-side hooks are skipped under `noSandbox()` |
+| `signal`          | `AbortSignal`                   | Abort cancels the launch handshake; once the TUI is live, exit semantics depend on the underlying agent process |
+| `copyToWorktree`  | `string[]`                      | Copies host items into the worktree before hooks fire (rejected with branch strategy `head`) |
+
+`maxIterations`, `completionSignal`, `idleTimeoutSeconds`, and `logging` are **not** part of `InteractiveOptions` — interactive sessions are user-driven, not iteration-bounded.
+
+#### `noSandbox()` and the `--dangerously-skip-permissions` policy
+
+Under bind-mount and isolated providers, sanddune passes `--dangerously-skip-permissions` to Claude Code so the agent can act freely inside the container. Under `noSandbox()`, the agent runs directly on the host and the flag is **not** passed — Claude Code's normal permission prompts stay active. This is enforced via the agent provider's `buildInteractiveCommand({ skipPermissions })` callback; the orchestrator decides `skipPermissions` based on the sandbox kind.
+
+`noSandbox()` is accepted only by `interactive()` / `wt.interactive()`. The type system rejects it for `run()` and `createSandbox()` — AFK runs require a real sandbox.
 
 ### Custom bind-mount providers
 

--- a/packages/sanddune/src/agents/claude-code.test.ts
+++ b/packages/sanddune/src/agents/claude-code.test.ts
@@ -38,6 +38,49 @@ describe("claudeCode buildCommand", () => {
   });
 });
 
+describe("claudeCode buildInteractiveCommand", () => {
+  test("does not include --dangerously-skip-permissions when skipPermissions is false (no-sandbox case)", () => {
+    const provider = claudeCode("claude-opus-4-7");
+    const cmd = provider.buildInteractiveCommand!({ skipPermissions: false });
+    expect(cmd).not.toContain("--dangerously-skip-permissions");
+    expect(cmd).toContain("claude");
+    expect(cmd).toContain("--model 'claude-opus-4-7'");
+  });
+
+  test("includes --dangerously-skip-permissions when skipPermissions is true (sandboxed case)", () => {
+    const provider = claudeCode("claude-opus-4-7");
+    const cmd = provider.buildInteractiveCommand!({ skipPermissions: true });
+    expect(cmd).toContain("--dangerously-skip-permissions");
+  });
+
+  test("appends a shell-quoted prompt when supplied", () => {
+    const provider = claudeCode("claude-opus-4-7");
+    const cmd = provider.buildInteractiveCommand!({
+      prompt: "do the thing",
+      skipPermissions: true,
+    });
+    expect(cmd.endsWith("'do the thing'")).toBe(true);
+  });
+
+  test("omits the prompt arg when no prompt is provided", () => {
+    const provider = claudeCode("claude-opus-4-7");
+    const cmd = provider.buildInteractiveCommand!({ skipPermissions: false });
+    // No trailing positional that looks like a quoted prompt.
+    expect(cmd).toMatch(/^claude --model '[^']+'$/);
+  });
+
+  test("does not emit --print/--output-format/--verbose (those are AFK-only)", () => {
+    const provider = claudeCode("claude-opus-4-7");
+    const cmd = provider.buildInteractiveCommand!({
+      prompt: "x",
+      skipPermissions: true,
+    });
+    expect(cmd).not.toContain("--print");
+    expect(cmd).not.toContain("--output-format");
+    expect(cmd).not.toContain("--verbose");
+  });
+});
+
 describe("claudeCode sessionCapture capability", () => {
   test("present by default", () => {
     expect(claudeCode("m").sessionCapture).toBeDefined();

--- a/packages/sanddune/src/agents/claude-code.ts
+++ b/packages/sanddune/src/agents/claude-code.ts
@@ -42,6 +42,12 @@ export function claudeCode(
       return args.join(" ");
     },
     parseLine: (line, iteration) => parseClaudeCodeLine(line, iteration),
+    buildInteractiveCommand: ({ prompt, skipPermissions }) => {
+      const args = ["claude", "--model", shellQuote(model)];
+      if (skipPermissions) args.push("--dangerously-skip-permissions");
+      if (prompt !== undefined) args.push(shellQuote(prompt));
+      return args.join(" ");
+    },
   };
 }
 

--- a/packages/sanddune/src/core/agent-provider.ts
+++ b/packages/sanddune/src/core/agent-provider.ts
@@ -25,6 +25,24 @@ export interface AgentBuildCommandInput {
   readonly resumeSessionId?: string;
 }
 
+/** Input passed by `interactive()` / `wt.interactive()` to an **agent
+ *  provider**'s `buildInteractiveCommand`. Mirrors `AgentBuildCommandInput`
+ *  for AFK runs but adds `skipPermissions` (per-call rather than always-on)
+ *  so the orchestrator can decide based on **sandbox kind** whether to
+ *  bypass the agent's permission prompts. With **no-sandbox**, the agent
+ *  runs directly on the **host** and `skipPermissions` is `false` so the
+ *  agent's normal prompts stay active. */
+export interface AgentInteractiveCommandInput {
+  /** Optional initial prompt the agent should open with. When omitted, the
+   *  agent's bare TUI is launched with no seed prompt. */
+  readonly prompt?: string;
+  /** When `true`, the agent provider should skip its normal permission
+   *  prompts (e.g. Claude Code's `--dangerously-skip-permissions`). The
+   *  orchestrator sets this for sandboxed providers (bind-mount / isolated)
+   *  and clears it for the **no-sandbox provider**. */
+  readonly skipPermissions: boolean;
+}
+
 /** Agent-specific glue for **agent session** capture and resume. Optional;
  *  agents that have no concept of a resumable session simply omit it and
  *  capture/resume become no-ops at the run-program level.
@@ -68,4 +86,9 @@ export interface AgentProvider {
   readonly sessionCapture?: AgentSessionCapture;
   buildCommand(input: AgentBuildCommandInput): string;
   parseLine(line: string, iteration: number): readonly AgentStreamEvent[];
+  /** Optional. Builds the shell command that launches the agent's TUI for
+   *  `interactive()` / `wt.interactive()`. Agents that do not have an
+   *  interactive UI omit this; calling `interactive()` with such an agent
+   *  rejects at runtime. */
+  buildInteractiveCommand?(input: AgentInteractiveCommandInput): string;
 }

--- a/packages/sanddune/src/core/index.ts
+++ b/packages/sanddune/src/core/index.ts
@@ -22,6 +22,7 @@ export type {
 
 export type {
   AgentBuildCommandInput,
+  AgentInteractiveCommandInput,
   AgentProvider,
   AgentSessionCapture,
   AgentStreamEvent,
@@ -33,6 +34,8 @@ export type {
   BindMountSandboxHandle,
   BindMountSandboxProvider,
   CreateSandboxProvider,
+  ExecInteractiveOptions,
+  ExecInteractiveResult,
   ExecOptions,
   ExecResult,
   InteractiveSandboxProvider,
@@ -48,7 +51,11 @@ export type { SandboxHooks } from "./hooks";
 
 export type { Timeouts } from "./timeouts";
 export type { LoggingOption } from "./logging";
-export type { PromptArgs, PromptOption } from "./prompt";
+export type {
+  OptionalPromptOption,
+  PromptArgs,
+  PromptOption,
+} from "./prompt";
 
 export { BUILT_IN_PROMPT_ARGS, preparePromptPipeline } from "./prompt-pipeline";
 export type {

--- a/packages/sanddune/src/core/interactive.ts
+++ b/packages/sanddune/src/core/interactive.ts
@@ -1,17 +1,19 @@
 import type { AgentProvider } from "./agent-provider";
 import type { SandboxHooks } from "./hooks";
-import type { PromptOption } from "./prompt";
+import type { OptionalPromptOption } from "./prompt";
 import type { InteractiveSandboxProvider } from "./sandbox-provider";
 import type { Timeouts } from "./timeouts";
 
 export type InteractiveOptions<
   S extends InteractiveSandboxProvider = InteractiveSandboxProvider,
-> = PromptOption & {
+> = OptionalPromptOption & {
   readonly agent: AgentProvider;
   readonly sandbox: S;
   readonly cwd?: string;
+  readonly name?: string;
   readonly env?: Readonly<Record<string, string>>;
   readonly hooks?: SandboxHooks;
   readonly timeouts?: Timeouts;
   readonly copyToWorktree?: readonly string[];
+  readonly signal?: AbortSignal;
 };

--- a/packages/sanddune/src/core/prompt.ts
+++ b/packages/sanddune/src/core/prompt.ts
@@ -11,3 +11,19 @@ export type PromptOption =
       readonly promptFile: string;
       readonly promptArgs?: PromptArgs;
     };
+
+/** Like `PromptOption`, but every field is optional — the user may launch
+ *  `interactive()` / `wt.interactive()` with no seed prompt at all. The
+ *  `prompt` + `promptFile` and `prompt` + `promptArgs` mutual-exclusion
+ *  rules still hold. */
+export type OptionalPromptOption =
+  | {
+      readonly prompt?: string;
+      readonly promptFile?: never;
+      readonly promptArgs?: never;
+    }
+  | {
+      readonly prompt?: never;
+      readonly promptFile: string;
+      readonly promptArgs?: PromptArgs;
+    };

--- a/packages/sanddune/src/core/sandbox-provider.ts
+++ b/packages/sanddune/src/core/sandbox-provider.ts
@@ -15,6 +15,17 @@ export interface ExecOptions {
   readonly signal?: AbortSignal;
 }
 
+export interface ExecInteractiveOptions {
+  readonly cwd?: string;
+  /** When the signal aborts, the underlying subprocess is killed (SIGTERM)
+   *  and the returned promise rejects with `signal.reason` verbatim. */
+  readonly signal?: AbortSignal;
+}
+
+export interface ExecInteractiveResult {
+  readonly exitCode: number;
+}
+
 export type SandboxKind = "bind-mount" | "isolated" | "no-sandbox";
 
 export interface SandboxProvider<K extends SandboxKind = SandboxKind> {
@@ -32,6 +43,14 @@ export interface BindMountCreateOptions {
 export interface BindMountSandboxHandle {
   readonly worktreePath: string;
   exec(command: string, options?: ExecOptions): Promise<ExecResult>;
+  /** Optional. Run a command with the host's stdin/stdout/stderr inherited
+   *  so the user can interact with the **agent**'s TUI. Used by
+   *  `interactive()` / `wt.interactive()`. Providers that omit this method
+   *  cannot be used by `interactive()`; the orchestrator throws clearly. */
+  execInteractive?(
+    command: string,
+    options?: ExecInteractiveOptions,
+  ): Promise<ExecInteractiveResult>;
   close(): Promise<void>;
 }
 

--- a/packages/sanddune/src/core/worktree.ts
+++ b/packages/sanddune/src/core/worktree.ts
@@ -2,7 +2,7 @@ import type { AgentProvider } from "./agent-provider";
 import type { NonHeadBranchStrategy } from "./branch-strategy";
 import type { SandboxHooks } from "./hooks";
 import type { LoggingOption } from "./logging";
-import type { PromptOption } from "./prompt";
+import type { OptionalPromptOption, PromptOption } from "./prompt";
 import type {
   CreateSandboxProvider,
   InteractiveSandboxProvider,
@@ -37,13 +37,16 @@ export type WorktreeRunOptions<
 
 export type WorktreeInteractiveOptions<
   S extends InteractiveSandboxProvider = InteractiveSandboxProvider,
-> = PromptOption & {
+> = OptionalPromptOption & {
   readonly agent: AgentProvider;
-  readonly sandbox: S;
+  /** Optional. Defaults to a `noSandbox()` provider — agent runs directly on
+   *  the **host** in the **worktree**. */
+  readonly sandbox?: S;
   readonly env?: Readonly<Record<string, string>>;
   readonly hooks?: SandboxHooks;
   readonly timeouts?: Timeouts;
   readonly copyToWorktree?: readonly string[];
+  readonly signal?: AbortSignal;
 };
 
 export interface WorktreeCreateSandboxOptions<

--- a/packages/sanddune/src/create-worktree.integration.test.ts
+++ b/packages/sanddune/src/create-worktree.integration.test.ts
@@ -7,7 +7,6 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { Effect, Layer } from "effect";
 import {
   AgentInvoker,
-  NotImplementedError,
   type AgentInvokerService,
   type AgentProvider,
   type BindMountSandboxHandle,
@@ -207,26 +206,6 @@ describe("createWorktree (integration)", () => {
     expect(close.preservedWorktreePath).toBe(wt.worktreePath);
     expect(existsSync(wt.worktreePath)).toBe(true);
     expect(existsSync(join(wt.worktreePath, "leftover.txt"))).toBe(true);
-  });
-
-  test("wt.interactive() throws NotImplementedError until #18 lands", async () => {
-    const wt = await createWorktreeProgram({
-      branchStrategy: { type: "branch", branch: "agent/tui" },
-      cwd: repo,
-    });
-    try {
-      const provider = makeBindMountProvider({ closeCalls: [] });
-      const agent: AgentProvider = {
-        name: "stub",
-        buildCommand: () => "true",
-        parseLine: () => [],
-      };
-      await expect(
-        wt.interactive({ agent, sandbox: provider, prompt: "x" }),
-      ).rejects.toThrow(NotImplementedError);
-    } finally {
-      await wt.close();
-    }
   });
 
   test("await using auto-disposes the worktree on block exit", async () => {

--- a/packages/sanddune/src/index.test.ts
+++ b/packages/sanddune/src/index.test.ts
@@ -1,19 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { NotImplementedError } from "./core";
-import { interactive } from "./index";
 import { docker } from "./sandboxes/docker";
 import { noSandbox } from "./sandboxes/no-sandbox";
 import { podman } from "./sandboxes/podman";
 import { vercel } from "./sandboxes/vercel";
-
-describe("entry-point stubs throw NotImplementedError", () => {
-  test("interactive", () => {
-    expect(() => interactive({} as never)).toThrow(NotImplementedError);
-    expect(() => interactive({} as never)).toThrow(
-      /^interactive is not implemented$/,
-    );
-  });
-});
 
 describe("sandbox provider factories", () => {
   test("docker returns a bind-mount provider", () => {
@@ -33,8 +23,14 @@ describe("sandbox provider factories", () => {
     expect(() => vercel()).toThrow(/^vercel is not implemented$/);
   });
 
-  test("noSandbox throws NotImplementedError", () => {
-    expect(() => noSandbox()).toThrow(NotImplementedError);
-    expect(() => noSandbox()).toThrow(/^noSandbox is not implemented$/);
+  test("noSandbox returns a no-sandbox provider", () => {
+    const provider = noSandbox();
+    expect(provider.kind).toBe("no-sandbox");
+    expect(provider.name).toBe("no-sandbox");
+  });
+
+  test("noSandbox carries env when supplied", () => {
+    const provider = noSandbox({ env: { FOO: "bar" } });
+    expect(provider.env).toEqual({ FOO: "bar" });
   });
 });

--- a/packages/sanddune/src/index.ts
+++ b/packages/sanddune/src/index.ts
@@ -1,4 +1,3 @@
-import { NotImplementedError } from "./core";
 import type {
   CreateSandboxOptions,
   CreateSandboxProvider,
@@ -13,6 +12,7 @@ import type {
 } from "./core";
 import { createSandboxProgram } from "./internal/create-sandbox-program";
 import { createWorktreeProgram } from "./internal/create-worktree-program";
+import { interactiveProgram } from "./internal/interactive-program";
 import { runProgram } from "./internal/run-program";
 
 export * from "./core";
@@ -39,7 +39,9 @@ export function createWorktree(
 }
 
 export function interactive<S extends InteractiveSandboxProvider>(
-  _options: InteractiveOptions<S>,
+  options: InteractiveOptions<S>,
 ): Promise<void> {
-  throw new NotImplementedError("interactive");
+  return interactiveProgram(
+    options as InteractiveOptions<InteractiveSandboxProvider>,
+  );
 }

--- a/packages/sanddune/src/interactive.integration.test.ts
+++ b/packages/sanddune/src/interactive.integration.test.ts
@@ -1,0 +1,371 @@
+import { spawnSync } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  type AgentProvider,
+  type BindMountSandboxProvider,
+} from "./core";
+import { createWorktree, interactive } from "./index";
+import { noSandbox } from "./sandboxes/no-sandbox";
+
+describe("interactive (integration)", () => {
+  let repo: string;
+
+  beforeEach(async () => {
+    repo = await mkdtemp(join(tmpdir(), "sanddune-int-it-"));
+    runSync("git", ["init", "--initial-branch=main"], repo);
+    runSync("git", ["config", "user.email", "test@example.com"], repo);
+    runSync("git", ["config", "user.name", "test"], repo);
+    runSync("git", ["config", "commit.gpgsign", "false"], repo);
+    await writeFile(join(repo, "README.md"), "seed\n");
+    runSync("git", ["add", "."], repo);
+    runSync("git", ["commit", "-m", "seed"], repo);
+  });
+
+  afterEach(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  test("noSandbox: agent runs on host with skipPermissions=false (no --dangerously-skip-permissions)", async () => {
+    const agent = makeMarkerAgent();
+    await interactive({
+      agent,
+      sandbox: noSandbox(),
+      prompt: "hello",
+      cwd: repo,
+    });
+    expect(readFileSync(join(repo, "skip.txt"), "utf8")).toBe("false\n");
+    expect(readFileSync(join(repo, "prompt.txt"), "utf8")).toBe("hello\n");
+  });
+
+  test("noSandbox: TUI launches without a prompt when none supplied", async () => {
+    const agent = makeMarkerAgent();
+    await interactive({
+      agent,
+      sandbox: noSandbox(),
+      cwd: repo,
+    });
+    expect(readFileSync(join(repo, "prompt.txt"), "utf8")).toBe("<no-prompt>\n");
+    expect(readFileSync(join(repo, "skip.txt"), "utf8")).toBe("false\n");
+  });
+
+  test("bind-mount: agent receives skipPermissions=true (the --dangerously-skip-permissions flag)", async () => {
+    const interactiveCalls: { command: string; cwd: string | undefined }[] =
+      [];
+    const closeCalls: number[] = [];
+    const provider = makeFakeBindMountProvider({
+      closeCalls,
+      interactiveCalls,
+    });
+    const agent: AgentProvider = {
+      name: "fake",
+      buildCommand: () => "true",
+      parseLine: () => [],
+      buildInteractiveCommand: ({ skipPermissions }) =>
+        `echo skip=${skipPermissions}`,
+    };
+    await interactive({
+      agent,
+      sandbox: provider,
+      prompt: "hi",
+      cwd: repo,
+    });
+    expect(interactiveCalls).toHaveLength(1);
+    expect(interactiveCalls[0]!.command).toBe("echo skip=true");
+    // Container is closed even on the happy path.
+    expect(closeCalls).toEqual([1]);
+  });
+
+  test("rejects when the agent provider lacks buildInteractiveCommand", async () => {
+    const agent: AgentProvider = {
+      name: "afk-only",
+      buildCommand: () => "true",
+      parseLine: () => [],
+    };
+    await expect(
+      interactive({
+        agent,
+        sandbox: noSandbox(),
+        prompt: "x",
+        cwd: repo,
+      }),
+    ).rejects.toThrow(/does not support interactive/);
+  });
+
+  test("rejects when the bind-mount handle lacks execInteractive", async () => {
+    const provider: BindMountSandboxProvider = {
+      kind: "bind-mount",
+      name: "no-interactive-handle",
+      create: async ({ worktreePath }) => ({
+        worktreePath,
+        exec: async () => ({ stdout: "", stderr: "", exitCode: 0 }),
+        close: async () => {},
+      }),
+    };
+    const agent: AgentProvider = {
+      name: "fake",
+      buildCommand: () => "true",
+      parseLine: () => [],
+      buildInteractiveCommand: () => "true",
+    };
+    await expect(
+      interactive({
+        agent,
+        sandbox: provider,
+        prompt: "x",
+        cwd: repo,
+      }),
+    ).rejects.toThrow(/does not support interactive sessions/);
+  });
+
+  test("cwd override: agent runs in the supplied cwd, not process.cwd()", async () => {
+    const other = await mkdtemp(join(tmpdir(), "sanddune-int-other-"));
+    runSync("git", ["init", "--initial-branch=main"], other);
+    runSync("git", ["config", "user.email", "t@e.com"], other);
+    runSync("git", ["config", "user.name", "t"], other);
+    runSync("git", ["config", "commit.gpgsign", "false"], other);
+    await writeFile(join(other, "README.md"), "other\n");
+    runSync("git", ["add", "."], other);
+    runSync("git", ["commit", "-m", "x"], other);
+
+    try {
+      const agent: AgentProvider = {
+        name: "fake",
+        buildCommand: () => "true",
+        parseLine: () => [],
+        buildInteractiveCommand: () => `printf 'here\\n' > marker.txt`,
+      };
+      await interactive({
+        agent,
+        sandbox: noSandbox(),
+        prompt: "x",
+        cwd: other,
+      });
+      expect(existsSync(join(other, "marker.txt"))).toBe(true);
+      expect(existsSync(join(repo, "marker.txt"))).toBe(false);
+    } finally {
+      await rm(other, { recursive: true, force: true });
+    }
+  });
+
+  test("signal: pre-aborted signal rejects with the caller's reason", async () => {
+    const agent: AgentProvider = {
+      name: "fake",
+      buildCommand: () => "true",
+      parseLine: () => [],
+      buildInteractiveCommand: () => `printf 'should-not-run\\n' > marker.txt`,
+    };
+
+    const controller = new AbortController();
+    controller.abort(new Error("user cancel"));
+
+    await expect(
+      interactive({
+        agent,
+        sandbox: noSandbox(),
+        prompt: "x",
+        cwd: repo,
+        signal: controller.signal,
+      }),
+    ).rejects.toThrow(/user cancel/);
+
+    // The agent never spawned, so no marker was written.
+    expect(existsSync(join(repo, "marker.txt"))).toBe(false);
+  });
+
+  test("env: declared sanddune env reaches the host-spawned agent (noSandbox)", async () => {
+    const agent: AgentProvider = {
+      name: "fake",
+      env: { FAKE_TOKEN: "from-agent" },
+      buildCommand: () => "true",
+      parseLine: () => [],
+      buildInteractiveCommand: () =>
+        `printf '%s\\n' "$FAKE_TOKEN" > token.txt`,
+    };
+    await interactive({
+      agent,
+      sandbox: noSandbox(),
+      prompt: "x",
+      cwd: repo,
+    });
+    expect(readFileSync(join(repo, "token.txt"), "utf8")).toBe("from-agent\n");
+  });
+});
+
+describe("wt.interactive (integration)", () => {
+  let repo: string;
+
+  beforeEach(async () => {
+    repo = await mkdtemp(join(tmpdir(), "sanddune-wti-it-"));
+    runSync("git", ["init", "--initial-branch=main"], repo);
+    runSync("git", ["config", "user.email", "test@example.com"], repo);
+    runSync("git", ["config", "user.name", "test"], repo);
+    runSync("git", ["config", "commit.gpgsign", "false"], repo);
+    await writeFile(join(repo, "README.md"), "seed\n");
+    runSync("git", ["add", "."], repo);
+    runSync("git", ["commit", "-m", "seed"], repo);
+  });
+
+  afterEach(async () => {
+    await rm(repo, { recursive: true, force: true });
+  });
+
+  test("defaults to noSandbox when no sandbox is supplied", async () => {
+    const wt = await createWorktree({
+      branchStrategy: { type: "branch", branch: "agent/tui" },
+      cwd: repo,
+    });
+    try {
+      const agent = makeMarkerAgent();
+      await wt.interactive({ agent, prompt: "hi" });
+      // skipPermissions=false confirms the default provider was noSandbox().
+      expect(readFileSync(join(wt.worktreePath, "skip.txt"), "utf8")).toBe(
+        "false\n",
+      );
+      expect(readFileSync(join(wt.worktreePath, "prompt.txt"), "utf8")).toBe(
+        "hi\n",
+      );
+    } finally {
+      await wt.close();
+    }
+  });
+
+  test("worktree survives the interactive session (ownership-follows-creation)", async () => {
+    const wt = await createWorktree({
+      branchStrategy: { type: "branch", branch: "agent/persist" },
+      cwd: repo,
+    });
+    const path = wt.worktreePath;
+    try {
+      const agent: AgentProvider = {
+        name: "fake",
+        buildCommand: () => "true",
+        parseLine: () => [],
+        buildInteractiveCommand: () => "true",
+      };
+      await wt.interactive({ agent });
+      // The parent Worktree owns the dir; interactive() must not tear it down.
+      expect(existsSync(path)).toBe(true);
+    } finally {
+      await wt.close();
+    }
+  });
+
+  test("explicit bind-mount sandbox: launched inside the worktree, with skipPermissions=true", async () => {
+    const wt = await createWorktree({
+      branchStrategy: { type: "branch", branch: "agent/bm-tui" },
+      cwd: repo,
+    });
+    try {
+      const interactiveCalls: { command: string; cwd: string | undefined }[] =
+        [];
+      const closeCalls: number[] = [];
+      const provider = makeFakeBindMountProvider({
+        closeCalls,
+        interactiveCalls,
+      });
+      const agent: AgentProvider = {
+        name: "fake",
+        buildCommand: () => "true",
+        parseLine: () => [],
+        buildInteractiveCommand: ({ skipPermissions }) =>
+          `echo skip=${skipPermissions}`,
+      };
+      await wt.interactive({ agent, sandbox: provider });
+      expect(interactiveCalls).toHaveLength(1);
+      expect(interactiveCalls[0]!.command).toBe("echo skip=true");
+      expect(closeCalls).toEqual([1]);
+    } finally {
+      await wt.close();
+    }
+  });
+
+  test("rejects after the parent worktree is closed", async () => {
+    const wt = await createWorktree({
+      branchStrategy: { type: "branch", branch: "agent/closed" },
+      cwd: repo,
+    });
+    await wt.close();
+    const agent: AgentProvider = {
+      name: "fake",
+      buildCommand: () => "true",
+      parseLine: () => [],
+      buildInteractiveCommand: () => "true",
+    };
+    await expect(wt.interactive({ agent })).rejects.toThrow(
+      /worktree is closed/,
+    );
+  });
+});
+
+/** A fake **agent provider** whose `buildInteractiveCommand` writes its
+ *  inputs (skipPermissions, prompt) to marker files in the worktree so the
+ *  test can verify them after the TUI "exits". */
+function makeMarkerAgent(): AgentProvider {
+  return {
+    name: "fake-marker",
+    buildCommand: () => "true",
+    parseLine: () => [],
+    buildInteractiveCommand: ({ prompt, skipPermissions }) =>
+      [
+        `printf '${skipPermissions ? "true" : "false"}\\n' > skip.txt`,
+        `printf '%s\\n' '${(prompt ?? "<no-prompt>").replace(/'/g, `'\\''`)}' > prompt.txt`,
+      ].join(" && "),
+  };
+}
+
+/** A bind-mount provider that records every `execInteractive` call and
+ *  runs the command synchronously via `spawnSync` so tests can assert
+ *  filesystem side effects without TTY allocation. */
+function makeFakeBindMountProvider(input: {
+  closeCalls: number[];
+  interactiveCalls: { command: string; cwd: string | undefined }[];
+}): BindMountSandboxProvider {
+  return {
+    kind: "bind-mount",
+    name: "fake-interactive",
+    create: async ({ worktreePath }) => ({
+      worktreePath,
+      exec: async (command, opts) => {
+        const r = spawnSync("sh", ["-c", command], {
+          cwd: opts?.cwd ?? worktreePath,
+          encoding: "utf8",
+        });
+        return {
+          stdout: r.stdout ?? "",
+          stderr: r.stderr ?? "",
+          exitCode: r.status ?? 0,
+        };
+      },
+      execInteractive: async (command, opts) => {
+        opts?.signal?.throwIfAborted?.();
+        input.interactiveCalls.push({ command, cwd: opts?.cwd });
+        const r = spawnSync("sh", ["-c", command], {
+          cwd: opts?.cwd ?? worktreePath,
+          encoding: "utf8",
+        });
+        return { exitCode: r.status ?? 0 };
+      },
+      close: async () => {
+        input.closeCalls.push(1);
+      },
+    }),
+  };
+}
+
+function runSync(
+  cmd: string,
+  args: readonly string[],
+  cwd: string,
+): { stdout: string; stderr: string } {
+  const r = spawnSync(cmd, args, { cwd, encoding: "utf8" });
+  if (r.status !== 0) {
+    throw new Error(
+      `${cmd} ${args.join(" ")} failed: ${r.stderr ?? ""}${r.stdout ?? ""}`,
+    );
+  }
+  return { stdout: r.stdout ?? "", stderr: r.stderr ?? "" };
+}

--- a/packages/sanddune/src/internal/create-worktree-program.ts
+++ b/packages/sanddune/src/internal/create-worktree-program.ts
@@ -2,6 +2,7 @@ import { resolve as resolvePath } from "node:path";
 import {
   type CloseResult,
   type CreateWorktreeOptions,
+  type InteractiveSandboxProvider,
   type RunResult,
   type Sandbox,
   type Worktree,
@@ -9,13 +10,14 @@ import {
   type WorktreeInteractiveOptions,
   type WorktreeRunOptions,
 } from "../core";
-import { NotImplementedError } from "../core";
+import { noSandbox } from "../sandboxes/no-sandbox";
 import {
   createSandboxFromWorktree,
   type CreateSandboxSeams,
 } from "./create-sandbox";
 import { resolveEnv } from "./env-resolver";
 import { gitCurrentBranch } from "./git";
+import { runInteractiveSession } from "./interactive-program";
 import { join } from "node:path";
 import { createWorktreeStrategy, type WorktreeStrategy } from "./worktree-strategy";
 
@@ -149,12 +151,35 @@ function makeWorktreeHandle(input: MakeWorktreeHandleInput): Worktree {
   };
 
   const wtInteractive = async (
-    _options: WorktreeInteractiveOptions,
+    options: WorktreeInteractiveOptions,
   ): Promise<void> => {
     ensureOpen();
-    // Deferred to #18 (Interactive + noSandbox). Type-level acceptance of
-    // all three sandbox kinds is already in `WorktreeInteractiveOptions`.
-    throw new NotImplementedError("Worktree.interactive");
+    // Per ADR-0010: `wt.interactive()` runs over the worktree this
+    // `Worktree` already owns; we never tear it down. The provider
+    // defaults to `noSandbox()` (CONTEXT.md / brief).
+    const provider: InteractiveSandboxProvider = options.sandbox ?? noSandbox();
+    const env = await resolveEnv({
+      processEnv: process.env,
+      sandduneEnvPath: join(hostRepoPath, ".sanddune", ".env"),
+      agentEnv: options.agent.env,
+      sandboxEnv: provider.env,
+      runOptionsEnv: options.env,
+    });
+
+    await runInteractiveSession({
+      agent: options.agent,
+      provider,
+      strategy,
+      branchStrategy: input.branchStrategy,
+      hostRepoPath,
+      env,
+      promptInput: extractWorktreePromptInput(options),
+      hooks: options.hooks,
+      timeouts: options.timeouts ?? input.creationTimeouts,
+      copyToWorktree: options.copyToWorktree ?? input.creationCopyToWorktree,
+      signal: options.signal,
+      ownsWorktree: false,
+    });
   };
 
   const wtCreateSandbox = async (
@@ -220,4 +245,22 @@ function makeWorktreeHandle(input: MakeWorktreeHandleInput): Worktree {
       await close();
     },
   };
+}
+
+function extractWorktreePromptInput(options: WorktreeInteractiveOptions): {
+  prompt?: string;
+  promptFile?: string;
+  promptArgs?: Readonly<Record<string, string | number>>;
+} {
+  const result: {
+    prompt?: string;
+    promptFile?: string;
+    promptArgs?: Readonly<Record<string, string | number>>;
+  } = {};
+  if (typeof options.prompt === "string") result.prompt = options.prompt;
+  if (typeof options.promptFile === "string") {
+    result.promptFile = options.promptFile;
+  }
+  if (options.promptArgs !== undefined) result.promptArgs = options.promptArgs;
+  return result;
 }

--- a/packages/sanddune/src/internal/host-process.ts
+++ b/packages/sanddune/src/internal/host-process.ts
@@ -7,6 +7,65 @@ export interface ProcessResult {
   readonly exitCode: number;
 }
 
+export interface SpawnHostInteractiveOptions {
+  readonly cwd?: string;
+  readonly env?: Readonly<Record<string, string>>;
+  /** When the signal aborts, the subprocess is killed (SIGTERM) and the
+   *  promise rejects with `signal.reason` verbatim. Pre-aborted signals
+   *  reject before spawn. */
+  readonly signal?: AbortSignal;
+}
+
+export interface InteractiveProcessResult {
+  readonly exitCode: number;
+}
+
+/** Spawn a host subprocess with stdin/stdout/stderr inherited from the
+ *  parent — used to launch an **agent**'s TUI for `interactive()` /
+ *  `wt.interactive()`. Resolves when the child exits; never reads or
+ *  buffers its output (the user is talking to it directly). */
+export function spawnHostInteractive(
+  cmd: string,
+  args: readonly string[],
+  options?: SpawnHostInteractiveOptions,
+): Promise<InteractiveProcessResult> {
+  return new Promise((resolvePromise, reject) => {
+    const signal = options?.signal;
+    if (signal?.aborted) {
+      reject(signal.reason);
+      return;
+    }
+
+    const proc = spawn(cmd, args, {
+      cwd: options?.cwd,
+      ...(options?.env !== undefined && {
+        env: { ...process.env, ...options.env },
+      }),
+      stdio: "inherit",
+    });
+
+    let aborted = false;
+    const onAbort = () => {
+      aborted = true;
+      proc.kill("SIGTERM");
+    };
+    if (signal) signal.addEventListener("abort", onAbort, { once: true });
+
+    proc.on("error", (error) => {
+      if (signal) signal.removeEventListener("abort", onAbort);
+      reject(error);
+    });
+    proc.on("close", (code) => {
+      if (signal) signal.removeEventListener("abort", onAbort);
+      if (aborted) {
+        reject(signal!.reason);
+        return;
+      }
+      resolvePromise({ exitCode: code ?? 0 });
+    });
+  });
+}
+
 export interface SpawnHostOptions {
   readonly cwd?: string;
   /** When set, stdout is split on newlines and each line is delivered as it

--- a/packages/sanddune/src/internal/interactive-program.ts
+++ b/packages/sanddune/src/internal/interactive-program.ts
@@ -1,0 +1,307 @@
+import { join, resolve as resolvePath } from "node:path";
+import {
+  preparePromptPipeline,
+  type AgentProvider,
+  type BindMountSandboxHandle,
+  type BindMountSandboxProvider,
+  type BranchStrategy,
+  type ExecResult,
+  type InteractiveOptions,
+  type InteractiveSandboxProvider,
+  type SandboxHooks,
+  type Timeouts,
+} from "../core";
+import { runCopyToWorktree } from "./copy-to-worktree";
+import { resolveEnv } from "./env-resolver";
+import { gitCurrentBranch } from "./git";
+import {
+  runHostHooksSequential,
+  runOnSandboxReadyParallel,
+} from "./hook-runner";
+import { spawnHost, spawnHostInteractive } from "./host-process";
+import {
+  createWorktreeStrategy,
+  type WorktreeStrategy,
+} from "./worktree-strategy";
+
+interface InteractivePromptInput {
+  readonly prompt?: string;
+  readonly promptFile?: string;
+  readonly promptArgs?: Readonly<Record<string, string | number>>;
+}
+
+/** Top-level `interactive()`. Owns the **worktree** lifecycle for the
+ *  duration of the TUI session and tears it down on exit (ADR-0010 — top
+ *  level is the bundled-convenience path). */
+export async function interactiveProgram(
+  options: InteractiveOptions<InteractiveSandboxProvider>,
+): Promise<void> {
+  const cwd = resolvePath(options.cwd ?? process.cwd());
+  const provider = options.sandbox;
+  const branchStrategy: BranchStrategy = defaultBranchStrategy(provider.kind);
+
+  const env = await resolveEnv({
+    processEnv: process.env,
+    sandduneEnvPath: join(cwd, ".sanddune", ".env"),
+    agentEnv: options.agent.env,
+    sandboxEnv: provider.env,
+    runOptionsEnv: options.env,
+  });
+
+  const targetBranch = await gitCurrentBranch(cwd);
+  const strategy = await createWorktreeStrategy({
+    strategy: branchStrategy,
+    providerKind: provider.kind,
+    cwd,
+    hostBranch: targetBranch,
+  });
+
+  await runInteractiveSession({
+    agent: options.agent,
+    provider,
+    strategy,
+    branchStrategy,
+    hostRepoPath: cwd,
+    env,
+    promptInput: extractPromptInput(options),
+    hooks: options.hooks,
+    timeouts: options.timeouts,
+    copyToWorktree: options.copyToWorktree,
+    signal: options.signal,
+    ownsWorktree: true,
+  });
+}
+
+export interface RunInteractiveSessionInput {
+  readonly agent: AgentProvider;
+  readonly provider: InteractiveSandboxProvider;
+  readonly strategy: WorktreeStrategy;
+  readonly branchStrategy: BranchStrategy;
+  readonly hostRepoPath: string;
+  readonly env: Readonly<Record<string, string>>;
+  readonly promptInput: InteractivePromptInput;
+  readonly hooks: SandboxHooks | undefined;
+  readonly timeouts: Timeouts | undefined;
+  readonly copyToWorktree: readonly string[] | undefined;
+  readonly signal: AbortSignal | undefined;
+  /** When `true`, this function tears down the worktree strategy on exit
+   *  (top-level `interactive()`). When `false`, the caller owns it
+   *  (`wt.interactive()` — parent `Worktree` survives the TUI session). */
+  readonly ownsWorktree: boolean;
+}
+
+/** Shared lifecycle for top-level `interactive()` and `wt.interactive()`.
+ *  Performs `copyToWorktree` → `host.onWorktreeReady` → branch on sandbox
+ *  kind to launch the TUI → `finalize()` → optional worktree teardown. */
+export async function runInteractiveSession(
+  input: RunInteractiveSessionInput,
+): Promise<void> {
+  let handle: BindMountSandboxHandle | undefined;
+  let runError: Error | undefined;
+
+  try {
+    await runCopyToWorktree({
+      items: input.copyToWorktree,
+      cwd: input.hostRepoPath,
+      worktreePath: input.strategy.worktreePath,
+      branchStrategy: input.branchStrategy,
+      timeoutMs: input.timeouts?.copyToWorktreeMs,
+      signal: input.signal,
+    });
+
+    await runHostHooksSequential(
+      input.hooks?.host?.onWorktreeReady,
+      input.signal,
+    );
+
+    if (input.provider.kind === "isolated") {
+      throw new Error(
+        `interactive() with an isolated sandbox provider is not yet implemented; got "${input.provider.name}".`,
+      );
+    }
+
+    if (input.provider.kind === "bind-mount") {
+      const provider = input.provider as BindMountSandboxProvider;
+      handle = await provider.create({
+        worktreePath: input.strategy.worktreePath,
+        hostRepoPath: input.hostRepoPath,
+        env: input.env,
+      });
+      if (handle.execInteractive === undefined) {
+        throw new Error(
+          `Sandbox provider "${provider.name}" does not support interactive sessions (no execInteractive).`,
+        );
+      }
+
+      await runOnSandboxReadyParallel({
+        hostHooks: input.hooks?.host?.onSandboxReady,
+        sandboxHooks: input.hooks?.sandbox?.onSandboxReady,
+        handle,
+        signal: input.signal,
+      });
+
+      const prompt = await resolvePrompt({
+        promptInput: input.promptInput,
+        sourceBranch: input.strategy.sourceBranch,
+        targetBranch: input.strategy.targetBranch,
+        execAdapter: (cmd) => handle!.exec(cmd),
+      });
+
+      const command = buildAgentInteractiveCommand({
+        agent: input.agent,
+        prompt,
+        skipPermissions: true,
+      });
+
+      await handle.execInteractive(command, {
+        ...(input.signal !== undefined && { signal: input.signal }),
+      });
+    } else {
+      // no-sandbox: run the agent directly on the host. Sandbox-side hooks
+      // are skipped silently — they have no place to run. Host-side
+      // onSandboxReady still fires (for callers that just want a
+      // pre-launch host hook).
+      await runHostHooksSequential(
+        input.hooks?.host?.onSandboxReady,
+        input.signal,
+      );
+
+      const worktreePath = input.strategy.worktreePath;
+      const prompt = await resolvePrompt({
+        promptInput: input.promptInput,
+        sourceBranch: input.strategy.sourceBranch,
+        targetBranch: input.strategy.targetBranch,
+        execAdapter: async (cmd) => {
+          const r = await spawnHost("sh", ["-c", cmd], {
+            cwd: worktreePath,
+          });
+          return { stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode };
+        },
+      });
+
+      const command = buildAgentInteractiveCommand({
+        agent: input.agent,
+        prompt,
+        skipPermissions: false,
+      });
+
+      await spawnHostInteractive("sh", ["-c", command], {
+        cwd: worktreePath,
+        env: input.env,
+        ...(input.signal !== undefined && { signal: input.signal }),
+      });
+    }
+
+    // For `merge-to-head`, ff-merge the temp source branch back into HEAD.
+    // No-op for `head` / `branch`. Only on success.
+    await input.strategy.finalize();
+  } catch (err) {
+    runError = err instanceof Error ? err : new Error(String(err));
+  } finally {
+    await closeHandleSafely(handle);
+    if (input.ownsWorktree) {
+      try {
+        await input.strategy.close();
+      } catch (e) {
+        process.stderr.write(
+          `sanddune: worktree teardown failed: ${
+            e instanceof Error ? e.message : String(e)
+          }\n`,
+        );
+      }
+    }
+  }
+
+  if (runError !== undefined) throw runError;
+}
+
+function defaultBranchStrategy(kind: string): BranchStrategy {
+  // Mirrors ADR-0009: bind-mount and no-sandbox default to head; isolated
+  // would default to merge-to-head (rejected later because isolated isn't
+  // implemented for interactive).
+  return kind === "isolated" ? { type: "merge-to-head" } : { type: "head" };
+}
+
+function extractPromptInput(
+  options: InteractiveOptions<InteractiveSandboxProvider>,
+): InteractivePromptInput {
+  const result: {
+    prompt?: string;
+    promptFile?: string;
+    promptArgs?: Readonly<Record<string, string | number>>;
+  } = {};
+  if (typeof options.prompt === "string") result.prompt = options.prompt;
+  if (typeof options.promptFile === "string") {
+    result.promptFile = options.promptFile;
+  }
+  if (options.promptArgs !== undefined) result.promptArgs = options.promptArgs;
+  return result;
+}
+
+interface ResolvePromptInput {
+  readonly promptInput: InteractivePromptInput;
+  readonly sourceBranch: string;
+  readonly targetBranch: string;
+  readonly execAdapter: (command: string) => Promise<ExecResult>;
+}
+
+async function resolvePrompt(
+  input: ResolvePromptInput,
+): Promise<string | undefined> {
+  if (
+    input.promptInput.prompt === undefined &&
+    input.promptInput.promptFile === undefined
+  ) {
+    return undefined;
+  }
+  const pipeline = await preparePromptPipeline({
+    ...(input.promptInput.prompt !== undefined && {
+      prompt: input.promptInput.prompt,
+    }),
+    ...(input.promptInput.promptFile !== undefined && {
+      promptFile: input.promptInput.promptFile,
+    }),
+    ...(input.promptInput.promptArgs !== undefined && {
+      promptArgs: input.promptInput.promptArgs,
+    }),
+    sourceBranch: input.sourceBranch,
+    targetBranch: input.targetBranch,
+  });
+  for (const key of pipeline.unusedPromptArgKeys) {
+    process.stderr.write(
+      `sanddune: warning — promptArgs.${key} was not used by the template\n`,
+    );
+  }
+  return pipeline.getPromptForIteration(input.execAdapter);
+}
+
+function buildAgentInteractiveCommand(input: {
+  readonly agent: AgentProvider;
+  readonly prompt: string | undefined;
+  readonly skipPermissions: boolean;
+}): string {
+  if (input.agent.buildInteractiveCommand === undefined) {
+    throw new Error(
+      `Agent provider "${input.agent.name}" does not support interactive() (no buildInteractiveCommand).`,
+    );
+  }
+  return input.agent.buildInteractiveCommand({
+    ...(input.prompt !== undefined && { prompt: input.prompt }),
+    skipPermissions: input.skipPermissions,
+  });
+}
+
+async function closeHandleSafely(
+  handle: BindMountSandboxHandle | undefined,
+): Promise<void> {
+  if (handle === undefined) return;
+  try {
+    await handle.close();
+  } catch (closeError) {
+    process.stderr.write(
+      `sanddune: sandbox teardown failed: ${
+        closeError instanceof Error ? closeError.message : String(closeError)
+      }\n`,
+    );
+  }
+}

--- a/packages/sanddune/src/sandboxes/docker.ts
+++ b/packages/sanddune/src/sandboxes/docker.ts
@@ -3,6 +3,8 @@ import type {
   BindMountCreateOptions,
   BindMountSandboxHandle,
   BindMountSandboxProvider,
+  ExecInteractiveOptions,
+  ExecInteractiveResult,
   ExecOptions,
   ExecResult,
 } from "../core";
@@ -11,7 +13,7 @@ import {
   resolveParentGitMount,
   type BindMount,
 } from "../internal/bind-mount-provisioning";
-import { spawnHost } from "../internal/host-process";
+import { spawnHost, spawnHostInteractive } from "../internal/host-process";
 
 export interface DockerOptions {
   readonly image?: string;
@@ -47,6 +49,8 @@ export function docker(options?: DockerOptions): BindMountSandboxProvider {
         worktreePath: SANDBOX_WORKTREE,
         exec: (command, execOptions) =>
           dockerExec(containerId, command, execOptions),
+        execInteractive: (command, interactiveOptions) =>
+          dockerExecInteractive(containerId, command, interactiveOptions),
         close: async () => {
           await dockerRm(containerId);
         },
@@ -109,6 +113,19 @@ async function dockerExec(
   return spawnHost("docker", args, {
     onLine: options?.onLine,
     signal: options?.signal,
+  });
+}
+
+async function dockerExecInteractive(
+  containerId: string,
+  command: string,
+  options?: ExecInteractiveOptions,
+): Promise<ExecInteractiveResult> {
+  const args = ["exec", "-it"];
+  if (options?.cwd) args.push("-w", options.cwd);
+  args.push(containerId, "sh", "-c", command);
+  return spawnHostInteractive("docker", args, {
+    ...(options?.signal && { signal: options.signal }),
   });
 }
 

--- a/packages/sanddune/src/sandboxes/no-sandbox.ts
+++ b/packages/sanddune/src/sandboxes/no-sandbox.ts
@@ -1,12 +1,20 @@
-import {
-  NotImplementedError,
-  type NoSandboxProvider,
-} from "../core";
+import type { NoSandboxProvider } from "../core";
 
 export interface NoSandboxOptions {
   readonly env?: Readonly<Record<string, string>>;
 }
 
-export function noSandbox(_options?: NoSandboxOptions): NoSandboxProvider {
-  throw new NotImplementedError("noSandbox");
+/** **No-sandbox provider** — runs the **agent** directly on the **host**.
+ *  Accepted only by `interactive()` / `wt.interactive()`; the type system
+ *  rejects it for `run()` and `createSandbox()` (CONTEXT.md).
+ *
+ *  The provider carries no factory method because there is no container to
+ *  create — the orchestrator special-cases `kind === "no-sandbox"` and
+ *  spawns the agent process on the host filesystem. */
+export function noSandbox(options?: NoSandboxOptions): NoSandboxProvider {
+  return {
+    kind: "no-sandbox",
+    name: "no-sandbox",
+    ...(options?.env !== undefined && { env: options.env }),
+  };
 }

--- a/packages/sanddune/src/types.test.ts
+++ b/packages/sanddune/src/types.test.ts
@@ -11,6 +11,7 @@ import type {
   NoSandboxProvider,
 } from "./core";
 import type { Sandbox } from "./core";
+import type { Worktree } from "./core";
 import {
   createSandbox,
   createWorktree,
@@ -79,6 +80,46 @@ function _typeChecks() {
   void interactive({
     agent: agentStub,
     sandbox: noSandboxStub,
+    prompt: "x",
+  });
+
+  // interactive() accepts no prompt at all — the TUI launches bare.
+  void interactive({
+    agent: agentStub,
+    sandbox: noSandboxStub,
+  });
+
+  // interactive() does not accept branchStrategy (top-level uses provider
+  // default; route through createWorktree() + wt.interactive() for non-default).
+  void interactive({
+    agent: agentStub,
+    sandbox: bindMountStub,
+    // @ts-expect-error branchStrategy is not accepted by top-level interactive()
+    branchStrategy: { type: "merge-to-head" },
+  });
+
+  // interactive() does not accept maxIterations / completionSignal — those
+  // are iteration-loop concerns; interactive sessions are user-driven.
+  void interactive({
+    agent: agentStub,
+    sandbox: noSandboxStub,
+    // @ts-expect-error maxIterations is not part of InteractiveOptions
+    maxIterations: 5,
+  });
+  void interactive({
+    agent: agentStub,
+    sandbox: noSandboxStub,
+    // @ts-expect-error completionSignal is not part of InteractiveOptions
+    completionSignal: "DONE",
+  });
+
+  // wt.interactive() defaults to noSandbox() — sandbox is optional.
+  const wtStub = null as unknown as Worktree;
+  void wtStub.interactive({ agent: agentStub });
+  void wtStub.interactive({ agent: agentStub, prompt: "x" });
+  void wtStub.interactive({
+    agent: agentStub,
+    sandbox: bindMountStub,
     prompt: "x",
   });
 


### PR DESCRIPTION
Closes #18.

## Summary
- Real `noSandbox()` provider — agent runs directly on the host with no container; accepted only by `interactive()` / `wt.interactive()` (the type system still rejects it for `run()` / `createSandbox()`).
- `interactive()` and `wt.interactive()` launch the agent's TUI and resolve when the user exits. Top-level `interactive()` always uses the provider's default **branch strategy** per [ADR-0009](docs/adr/0009-branch-strategy-per-call.md); non-default routes through `createWorktree() + wt.interactive()`. `wt.interactive()`'s `sandbox` is optional and defaults to `noSandbox()`.
- `claudeCode().buildInteractiveCommand` emits `claude --model <m>` plus `--dangerously-skip-permissions` only when `skipPermissions: true`. The orchestrator sets it for **bind-mount** / **isolated** providers and clears it for **no-sandbox** so the agent's normal permission prompts stay active. The AFK `buildCommand` is unchanged.
- `BindMountSandboxHandle.execInteractive?` is a new optional method; `docker()` implements it via `docker exec -it`. `spawnHostInteractive()` is the host-side stdio-inherited launcher (with `signal` support).

## What's not in scope (deferred)
- Real isolated-provider runtime (`vercel()` is still a stub; `interactive()` accepts the type but rejects at runtime).
- `Sandbox.interactive()` on long-lived sandboxes.
- `resumeSession` plumbing for interactive TUIs.

## Test plan
- [x] `bun test` — 238 pass, 0 fail (12 new in `interactive.integration.test.ts`, 5 new in `claude-code.test.ts` for `buildInteractiveCommand`)
- [x] `bun run typecheck` — clean (new `@ts-expect-error` assertions in `types.test.ts` cover: no `branchStrategy` / `maxIterations` / `completionSignal` on `InteractiveOptions`; `wt.interactive({ agent })` with no `sandbox` typechecks)
- [x] `bun run build` — clean (new `sandboxes/no-sandbox.js` entry emitted)
- [ ] Manual smoke: `interactive({ agent: claudeCode(...), sandbox: noSandbox() })` against a local Claude Code install (cannot exercise in CI — TUI requires a TTY)
- [ ] Manual smoke: `interactive({ ..., sandbox: docker() })` end-to-end against the repo's `.sanddune/Dockerfile`

## Notes for reviewers
- Top-level `interactive()` rejecting `branchStrategy` is enforced at the type level (see new `@ts-expect-error` in `types.test.ts`).
- For `noSandbox`, sandbox-side hooks are silently skipped (no place to run); host-side hooks still fire.
- The integration test for the bind-mount path uses a fake provider whose `execInteractive` runs commands via `spawnSync` — no Docker required in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)